### PR TITLE
Fix potential Postgres insert failure

### DIFF
--- a/lib/App/Netdisco/Core/Discover.pm
+++ b/lib/App/Netdisco/Core/Discover.pm
@@ -144,7 +144,7 @@ sub store_device {
 
   my @properties = qw/
     snmp_ver
-    description uptime contact name location
+    description uptime name
     layers ports mac
     ps1_type ps2_type ps1_status ps2_status
     fan slots
@@ -157,6 +157,9 @@ sub store_device {
 
   $device->set_column( model  => Encode::decode('UTF-8', $snmp->model)  );
   $device->set_column( serial => Encode::decode('UTF-8', $snmp->serial) );
+  $device->set_column( contact => Encode::decode('UTF-8', $snmp->contact) );
+  $device->set_column( location => Encode::decode('UTF-8', $snmp->location) );
+
 
   $device->set_column( snmp_class => $snmp->class );
   $device->set_column( last_discover => \'now()' );


### PR DESCRIPTION
Hi Oliver & Netdisco Team

We encountered some devices with random non-utf8 data in syscontact and syslocation,
making the insert fail with "ERROR:  invalid byte sequence for encoding "UTF8"
on discovery. E.g. 

```
[13394] 2017-04-20 07:10:40  info discover: status error: error running job: DBIx::Class::Storage::DBI::_dbh_execute(): 
DBI Exception: DBD::Pg::st execute failed: ERROR:  invalid byte sequence for encoding "UTF8": 
0xfc [for Statement "INSERT INTO device ( contact, description, dns, fan, ip, last_discover, layers, 
location, mac, model, name, os, os_ver, ports, ps1_status, ps1_type, ps2_status, ps2_type, serial, 
slots, snmp_class, snmp_comm, snmp_ver, uptime, vendor) 
VALUES ( ?, ?, ?, ?, ?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )" 
with ParamValues: 1=' Mï¿½ller Franz, Oberhinterzollikofen', 2='Cisco Prime NAM Appliance 2320 ("NAM2320-K9"), Version 5.1(3) RELEASE SOFTWARE [fc2]... and so on
```
I added location and contact to the columns that get an explicit Encode::decode first, that seems to have fixed the issue. Not sure if that was already done on model and serial for the same reason.

Christian

PS there might even be a safer method that replaces the characters with a default bad codepoint character, described here: http://stackoverflow.com/a/14509489/571215. But it made no visible difference in our case so I just stuck with what was already in the code.
