### PR TITLE
Missing Pod::Usage dependency

### DIFF
--- a/bin/netdisco-sshcollector
+++ b/bin/netdisco-sshcollector
@@ -49,6 +49,7 @@ use Data::Printer;
 use Module::Load ();
 use Net::OpenSSH;
 use MCE::Loop Sereal => 1;
+use Pod::Usage 'pod2usage';
 
 use Getopt::Long;
 Getopt::Long::Configure ("bundling");


### PR DESCRIPTION
It is necessary to include the "Pod::Usage" module to use the "pod2usage" method. Otherwise, an error occurs if an incorrect CLI option is used.