### PR TITLE
fix sshcollector errors when devices are empty

### DIFF
--- a/bin/netdisco-sshcollector
+++ b/bin/netdisco-sshcollector
@@ -76,6 +76,7 @@ Dancer::Logger->init('console', $CONFIG);
 
 MCE::Loop::init { chunk_size => 1 };
 my %stats;
+$stats{entry} = 0;
 
 exit main();
 
@@ -130,13 +131,11 @@ sub process {
     my $arpentries = [ $device->arpnip($hostlabel, $ssh, $args) ];
 
     # debug p $arpentries;
-    if (scalar @$arpentries) {
-        hostnames_resolve_async($arpentries);
-        return [$hostlabel, $arpentries];
-    }
-    else {
+    if (not scalar @$arpentries) {
         warning "WARNING: no entries received from <$hostlabel>";
     }
+    hostnames_resolve_async($arpentries);
+    return [$hostlabel, $arpentries];
 }
 
 sub store_arpentries {


### PR DESCRIPTION
While setting up an sshcollector, I found that the script doesn't handle an
arpless device very gracefully.  The log looks like:

	[46567] 2018-04-10 16:59:08  warn WARNING: no entries received from <IP>
	Can't use string ("1") as an ARRAY ref while "strict refs" in use at perl5/bin/netdisco-sshcollector line 114, <__ANONIO__> line 3.

This is fixed by making the process function always return the expected
structure, even if it's empty.  After this error, the following errors showed
up:

	[53232] 2018-04-10 17:06:15  warn WARNING: no entries received from <IP>
	[53210] 2018-04-10 17:06:15  info  [134.71.0.126] arpnip - retrieved 0 entries
	Use of uninitialized value in sprintf at perl5/bin/netdisco-sshcollector line 119, <__ANONIO__> line 3.
	[53210] 2018-04-10 17:06:15  info arpnip - processed  ARP Cache entries from 1 devices

This is because $stats{entry} only becomes an integer by being incremented, so
if there aren't any entries, it never exists.  This is fixed by starting it at 0.