### PR TITLE
dump sshcollector stderr into null

### DIFF
--- a/bin/netdisco-sshcollector
+++ b/bin/netdisco-sshcollector
@@ -97,6 +97,7 @@ sub main {
                 password => $host->{password},
                 timeout => 30,
                 async => 0,
+                default_stderr_file => '/dev/null',
                 master_opts => [
                     -o => "StrictHostKeyChecking=no",
                     -o => "BatchMode=no"


### PR DESCRIPTION
If SSH prints anything to stderr, it leaks out to the caller of sshcollect. This change dumps it into /dev/null instead.

It might be better to collect it and output it for debug purposes, but this cleans up logging in the interim.

I'm only able to test this with the Palo Alto plugin so I apologize if it breaks one of the others.