### PR TITLE
Phone icon for nodes

### DIFF
--- a/share/config.yml
+++ b/share/config.yml
@@ -158,11 +158,11 @@ system_reports:
     label: 'Error Disabled Ports'
     category: Port
     columns:
-    - { ip: Device } 
-    - { dns: DNS } 
-    - { port: Port } 
-    - { name: Description } 
-    - { reason: Reason } 
+    - { ip: Device }
+    - { dns: DNS }
+    - { port: Port }
+    - { name: Description }
+    - { reason: Reason }
     query: |
       SELECT dp.ip, d.dns, dp.port, dp.name, properties.error_disable_cause AS reason
         FROM device_port dp
@@ -289,6 +289,10 @@ ignore_private_nets: false
 reverse_sysname: false
 phone_capabilities:
   - '(?i:phone)'
+phone_macvendor:
+  - '00:00:00'
+  - '01-AB-FF'
+  - 'ab:2e:00'
 phone_platforms:
   - '(?i:mitel.5\d{3})'
 wap_capabilities:

--- a/share/views/ajax/device/ports.tt
+++ b/share/views/ajax/device/ports.tt
@@ -316,11 +316,20 @@
           [% '<br/>' IF (row.remote_ip OR row.is_uplink) OR NOT loop.first %]
           [% '<i class="icon-book"></i>&nbsp; ' IF NOT node.active %]
           [% '<i class="icon-signal"></i>&nbsp;' IF node.wireless.defined %]
+          [% IF settings.phone_macvendor %]
+            [% FOREACH vendor IN settings.phone_macvendor %]
+              [% vendor = vendor.replace('-',':') %]
+              [% IF row.remote_is_phone AND node.net_mac.$mac_format_call.match(vendor.lower) %]
+                <i class="icon-phone"></i>&nbsp;
+                [% LAST %]
+              [% END %]
+            [% END %]
+          [% END %]
           <a href="[% search_node %]&q=[% node.net_mac.$mac_format_call | uri %]">
             [% node.net_mac.$mac_format_call | html_entity %]</a>
           [% IF (node.vlan > 0) && (node.vlan != row.vlan) %]
             (on vlan [% node.vlan | html_entity %])
-          [% END %]            
+          [% END %]
           [% IF params.n_ssid AND node.wireless.defined %]
             (SSID:
             [% FOREACH wlan IN node.wireless %]


### PR DESCRIPTION
Removed by issue [#379](https://github.com/netdisco/netdisco/issues/379). Parameter "phone_platforms" doesn't work with all phone types because LLDP field "SysDescr" isn't always available. For these cases, the goal of this modification is to allow the possibility to define a new parameter "phone_mac_vendor" into deployment.yml configuration file in order to list phone's MAC vendor (first three MAC address octets) to match phone nodes MAC address and display the relevant icon.
New parameter "phone_mac_vendor" accepts MAC vendor uppercase/lowercase formats and dash or colon characters.