### PR TITLE
1 more isdn interface to ignore

### DIFF
--- a/share/config.yml
+++ b/share/config.yml
@@ -281,6 +281,7 @@ ignore_interfaces:
   - 'BRI\S+-Bearer Channel'
   - 'BRI\S+-Physical'
   - 'BRI\S+-Signalling'
+  - 'BRI\S+-Signaling'
   - 'Embedded-Service-Engine\d+\/\d+'
   - 'Virtual-Template\d+'
   - 'Virtual-Access\d+'


### PR DESCRIPTION
not sure if this is a typo or not, but bri singaling interfaces have 1 'l' on cisco devices.

"BRI0-Signaling" was taken from a netdisco report, router is a "897VaK9" running ios "15.5(3)M7".

as such, i've added the 1 'l' variant to the ignore_interfaces list. if this was indeed a typo perhaps the double 'll' variant can be deleted.