### PR TITLE
In discovery, ignore 'notPresent' interfaces

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -181,6 +181,13 @@ register_worker({ phase => 'early', driver => 'snmp' }, sub {
           next;
       }
 
+      # Skip physical interfaces which are physically 'notPresent'
+      if (defined $i_up->{$entry} and $i_up->{$entry} eq 'notPresent' and $i_type->{$entry} eq 'ethernetCsmacd') {
+          debug sprintf ' [%s] interfaces - ignoring %s (%s) (%s)',
+            $device->ip, $entry, $port, $i_up->{$entry};
+          next;
+      }
+
       my $lc = $i_lastchange->{$entry} || 0;
       if (not $dev_uptime_wrapped and $lc > $dev_uptime) {
           info sprintf ' [%s] interfaces - device uptime wrapped (%s) - correcting',
@@ -263,7 +270,7 @@ sub _get_vrf_list {
         if ($vrf =~ /^\S+$/) {
             my $ctx_name = pack("C*",split(/\./,$idx));
             $ctx_name =~ s/.*[^[:print:]]+//;
-            debug sprintf(' [%s] Discover VRF %s with SNMP Context %s', $device->ip, $vrf, $ctx_name); 
+            debug sprintf(' [%s] Discover VRF %s with SNMP Context %s', $device->ip, $vrf, $ctx_name);
             push (@ok_vrfs, $ctx_name);
         }
     }


### PR DESCRIPTION
During discovery, ignore all interfaces of type 'ethernetCsmacd'
which are described as 'notPresent'.

The CiscoSB class devices will pre-define phantom interface place-
holders in the MIB for any physical interface which /might/ be in
the stack.  In a large stack this may lead to hundreds of such
phantom interfaces, which just take up vertical space in the GUI
and rows in the DB.

By checking for type == ethernetCsmacd, we allow the Port-Channel
and Tunnel interfaces, which also get described as notPresent, to
appear.