### PR TITLE
ignore notpresent interfaces, with type filtering config item

### DIFF
--- a/share/config.yml
+++ b/share/config.yml
@@ -294,6 +294,10 @@ ignore_interfaces:
   - 'Ethernet(?:-| )QOS Packet Schedu?ler'
   - 'Ethernet(?:-| )WFP (?:802\.3|Native) MAC Layer Lightweight Filter'
   - 'ii\d\/\d\/\d+'
+ignore_notpresent_types:
+  - 'ethernetCsmacd'
+  - 'tunnel'
+  - 'ieee8023adLag'
 ignore_private_nets: false
 reverse_sysname: false
 phone_capabilities:


### PR DESCRIPTION
as #463 by nic. but now with config item to select types to filter, which can be set to [] to not filter at all.

went through my device database, seems only cisco small business switches have "notpresent" interfaces at first glance. this can be either down/notPresent or up/notPresent.

side note: really old ros versions (1.1.2.0) report port channel interfaces as ethernetCsmacd.