### PR TITLE
make job queue list in webinterface configurable

### DIFF
--- a/lib/App/Netdisco/JobQueue.pm
+++ b/lib/App/Netdisco/JobQueue.pm
@@ -59,8 +59,9 @@ Performs initialisation of the Job Queue backend.
 
 =head2 jq_log()
 
-Returns a list of the most recent 50 jobs in the queue. Jobs are returned as
-objects which implement the Netdisco job instance interface (see below).
+Returns a list of the most recent jobs as defined in C<jobs_qdepth> from the
+queue. Jobs are returned as objects which implement the Netdisco job instance
+interface (see below).
 
 =head2 jq_userlog( $user )
 

--- a/lib/App/Netdisco/JobQueue/PostgreSQL.pm
+++ b/lib/App/Netdisco/JobQueue/PostgreSQL.pm
@@ -273,7 +273,7 @@ sub jq_log {
   return schema('netdisco')->resultset('Admin')->search({}, {
     prefetch => 'target',
     order_by => { -desc => [qw/entered device action/] },
-    rows => 50,
+    rows     => (setting('jobs_qdepth') || setting('jobs_qdepth') == 0 ? 0 : 50),
   })->with_times->hri->all;
 }
 

--- a/lib/App/Netdisco/JobQueue/PostgreSQL.pm
+++ b/lib/App/Netdisco/JobQueue/PostgreSQL.pm
@@ -273,7 +273,7 @@ sub jq_log {
   return schema('netdisco')->resultset('Admin')->search({}, {
     prefetch => 'target',
     order_by => { -desc => [qw/entered device action/] },
-    rows     => (setting('jobs_qdepth') || setting('jobs_qdepth') == 0 ? 0 : 50),
+    rows     => (setting('jobs_qdepth') || 50),
   })->with_times->hri->all;
 }
 

--- a/share/config.yml
+++ b/share/config.yml
@@ -322,6 +322,7 @@ workers:
 
 # 50 minutes
 jobs_stale_after: 3000
+jobs_qdepth: 50
 
 dns:
   max_outstanding: 50


### PR DESCRIPTION
related to #466 

add an option to set the amount of jobs returned by the job queue webinterface.  when a discoverall fires off we have around 1000 jobs in the queue. the job queue webinterface does not always seem to show running or queued jobs before completed ones.

with the default of 50 sometimes we just get a list of completed jobs with no way to check (or stop/delete) if there are queued or running jobs. this adds a option in the configuration so you can increase the amount of jobs shown. i prefer 200 jobs with a refresh rate of 30 seconds.

perhaps a dropdown box based on table_showrecordsmenu would also be an option.

or a sorting preference (first running, then queued, then error, then done, etc), but then you will also need to define a maximum timeframe based on job submission. but that's overengineering it imo.

