### PR TITLE
allow snmp::info base class in netdisco-do

### DIFF
--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -301,16 +301,30 @@ the leaf (such as C<interfaces> or C<uptime>).
 
 If you wish to test with a device class other than that discovered, prefix the
 leaf with the class short name, for example "C<Layer3::C3550::interfaces>" or
-"C<Layer2::HP::uptime>". Using "C<::>" as prefix will test against the base
-"C<SNMP::Info>" class.
+"C<Layer2::HP::uptime>". Using "C<::>" as the start of the prefix will test
+against the base "C<SNMP::Info>" class.
+
+As well, SNMP object names can be used as an argument for "C<-e>", so you can
+use C<ifName> for example, which will use the netdisco-mibs files for
+translations.
+
+All "C<-e>" parameters are case sensitive.
 
  ~/bin/netdisco-do show -d 192.0.2.1 -e interfaces
  ~/bin/netdisco-do show -d 192.0.2.1 -e Layer2::HP::interfaces
  ~/bin/netdisco-do show -d 192.0.2.1 -e ::interfaces
+ ~/bin/netdisco-do show -d 192.0.2.1 -e ifName
 
-A parameter may be passed to the C<SNMP::Info> method in the C<-p> parameter:
+A parameter may be passed to the C<SNMP::Info> method or SNMP object in the
+"C<-p>" parameter:
 
  ~/bin/netdisco-do show -d 192.0.2.1 -e has_layer -p 3
+ ~/bin/netdisco-do show -d 192.0.2.1 -e ifName -p 2
+
+The "C<-e>" parameter C<specify> will dump the known configuration for the
+specified device.
+
+ ~/bin/netdisco-do show -d 192.0.2.1 -e specify
 
 =head2 psql
 

--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -321,7 +321,7 @@ A parameter may be passed to the C<SNMP::Info> method or SNMP object in the
  ~/bin/netdisco-do show -d 192.0.2.1 -e has_layer -p 3
  ~/bin/netdisco-do show -d 192.0.2.1 -e ifName -p 2
 
-The "C<-e>" parameter C<specify> will dump the known configuration for the
+The "C<-e>" parameter C<specify> will show the used configuration for the
 specified device.
 
  ~/bin/netdisco-do show -d 192.0.2.1 -e specify

--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -301,10 +301,12 @@ the leaf (such as C<interfaces> or C<uptime>).
 
 If you wish to test with a device class other than that discovered, prefix the
 leaf with the class short name, for example "C<Layer3::C3550::interfaces>" or
-"C<Layer2::HP::uptime>".
+"C<Layer2::HP::uptime>". Using "C<::>" as prefix will test against the base
+"C<SNMP::Info>" class.
 
  ~/bin/netdisco-do show -d 192.0.2.1 -e interfaces
  ~/bin/netdisco-do show -d 192.0.2.1 -e Layer2::HP::interfaces
+ ~/bin/netdisco-do show -d 192.0.2.1 -e ::interfaces
 
 A parameter may be passed to the C<SNMP::Info> method in the C<-p> parameter:
 

--- a/lib/App/Netdisco/Worker/Plugin/Show.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Show.pm
@@ -22,9 +22,9 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
   $extra = pop @values;
   if (scalar(@values)) {
     $class = "SNMP::Info";
-    foreach (@values) {
-      last if ($_ eq '');
-      $class = $class.'::'.$_;
+    foreach my $v (@values) {
+      last if ($v eq '');
+      $class = $class.'::'.$v;
     }
   }
 

--- a/lib/App/Netdisco/Worker/Plugin/Show.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Show.pm
@@ -18,13 +18,14 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
   my ($device, $port, $extra) = map {$job->$_} qw/device port extra/;
 
   $extra ||= 'interfaces'; my $class = undef;
-  ($class, $extra) = split(/::([^:]+)$/, $extra);
-  if ($class and $extra) {
-      $class = 'SNMP::Info::'.$class;
-  }
-  else {
-      $extra = $class;
-      undef $class;
+  my @values = split /::/, $extra;
+  $extra = pop @values;
+  if (scalar(@values)) {
+    $class = "SNMP::Info";
+    foreach (@values) {
+      last if ($_ eq '');
+      $class = $class.'::'.$_;
+    }
   }
 
   my $i = App::Netdisco::Transport::SNMP->reader_for($device, $class);


### PR DESCRIPTION
had almost created an issue for this, then i thought i might as well give it a go myself. would like a few more eyes on this. perhaps it could be written more efficiently, but i find this to be quite readable.

the idea is that if you prefix -e with :: you will use plain snmp::info without more specific modules loaded.

as a bonus this also also makes this no longer fail, but more error handling could still be added.
```
netdisco-do show -d 10.40.254.65 -e ::interfaces
[18660] 2019-01-11 23:49:48  info App::Netdisco version 2.040002 loaded.
[18660] 2019-01-11 23:49:48  info show: [10.40.254.65]/::interfaces started at Sat Jan 12 00:49:48 2019
Use of uninitialized value $sub_name in string eq at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4986.
Use of uninitialized value $sub_name in regexp compilation at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 5004.
Use of uninitialized value in subroutine entry at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4906.
Use of uninitialized value $method in string eq at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4908.
Use of uninitialized value $method in pattern match (m//) at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4797.
Use of uninitialized value $attr in substitution (s///) at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4799.
Use of uninitialized value $attr in substitution (s///) at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4800.
Use of uninitialized value $attr in hash element at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4805.
Use of uninitialized value $attr in hash element at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4805.
Use of uninitialized value $leaf_name in pattern match (m//) at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4808.
Use of uninitialized value $leaf_name in pattern match (m//) at /home/netdisco/perl5/lib/perl5/SNMP/Info.pm line 4821.

```


since it took longer as expected i'll be lazy and copy/paste my issue text.

-----------------


<!--- Provide a general summary of the issue in the Title above -->
i'm trying to debug a few things for which it would be handy if i could use the base snmp::info class, but it seems `netdisco-do show -e` has no support for selecting that

<!-- stop! If your ticket is about a device not being detected correctly, -->
<!-- see SNMP::Info: https://github.com/netdisco/snmp-info/issues/new -->

<!-- stop! If you have new MIBs to submit, -->
<!-- see netdisco-mibs: https://github.com/netdisco/netdisco-mibs/issues/new -->

<!-- everything else about Netdisco's behaviour is good, here :-D -->

## Expected Behavior
have some way of using functions without any overrides from more specific classes.

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
https://github.com/netdisco/netdisco/blob/master/lib/App/Netdisco/Worker/Plugin/Show.pm#L20
i don't see a way to use base snmp::info here.

## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
<!--- or ideas how to implement the addition or change -->
add some way of selecting the base snmp::info class, perhaps using -e ::<action> so select this? so just using :: would select base snmp::info.

## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
this would help with debugging, so if a function is overridden like interfaces(), we can compare what snmp::info thinks it should be as compared to what a more specific class overwrites it to.

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Netdisco version used: HEAD

