### PR TITLE
always prefer device entries over node_ip entries

### DIFF
--- a/lib/App/Netdisco/Web/Plugin/Report/IpInventory.pm
+++ b/lib/App/Netdisco/Web/Plugin/Report/IpInventory.pm
@@ -110,7 +110,7 @@ get '/ajax/content/report/ipinventory' => require_login sub {
                 'ip',     'mac',  'dns',  'time_last', 'time_first',
                 'active', 'node', 'age'
             ],
-            order_by => [{-asc => 'ip'}, {-desc => 'active'}],
+            order_by => [{-asc => 'ip'}, {-desc => 'active'}, {-asc => 'node'}],
         }
     )->as_query;
 


### PR DESCRIPTION
first part of the fix for #514 

select distinct needs to be provided with an explicit order to return consistent results. ip & active suffices for nodes, but if it's a device with an entry in node_ip we get random results. so also order on boolean node to prefer device entries in that case.

(at the time of writing however none of my devices return a mac address, which might be another bug)