### PR TITLE
Fix an issue with the reindixing for VRF

### DIFF
--- a/lib/App/Netdisco/Util/SNMP.pm
+++ b/lib/App/Netdisco/Util/SNMP.pm
@@ -100,11 +100,19 @@ sub snmp_comm_reindex {
       }
       $prefix ||= 'vlan-';
 
-      debug
-        sprintf '[%s] reindexing to "%s%s" (ver: %s, class: %s)',
+      if ($vlan =~ /^[0-9]+$/i && $vlan) { 
+        debug sprintf '[%s] reindexing to "%s%s" (ver: %s, class: %s)',
         $device->ip, $prefix, $vlan, $ver, $snmp->class;
-      $vlan ? $snmp->update(Context => ($prefix . $vlan))
-            : $snmp->update(Context => '');
+        $snmp->update(Context => ($prefix . $vlan));
+      } elsif ($vlan =~ /^[a-z0-9]+$/i && $vlan) { 
+        debug sprintf '[%s] reindexing to "%s" (ver: %s, class: %s)',
+          $device->ip, $vlan, $ver, $snmp->class;
+        $snmp->update(Context => ($vlan));
+      } else { 
+        debug sprintf '[%s] reindexing without context (ver: %s, class: %s)',
+          $device->ip, $ver, $snmp->class;
+        $snmp->update(Context => ''); 
+      }
   }
   else {
       my $comm = $snmp->snmp_comm;


### PR DESCRIPTION
When we perform the reindexing for the VRF, we need to avoid to use the prefix vlan- for SNMP context.