### PR TITLE
netdisco rancid export

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+2.042006 - 2019-xx-xx
+
+  [NEW FEATURES]
+
+  * netdisco-rancid-export is now a noop
+
 2.042005 - 2019-04-03
 
   [ENHANCEMENTS]

--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -383,6 +383,13 @@ Set the PoE on/off status on a device port. Requires the C<-d> parameter
  ~/bin/netdisco-do power -d 192.0.2.1 -p FastEthernet0/1 -e on
  ~/bin/netdisco-do power -d 192.0.2.1 -p FastEthernet0/1 -e off
 
+=head2 makerancidconf
+
+Generates rancid configuration for known devices. See
+L<App::Netdisco::Worker::Plugin::MakeRancidConf> for configuration needs.
+
+ ~/bin/netdisco-do makerancidconf
+
 =head2 dumpconfig
 
 Will dump the loaded and parsed configuration for the application. Pass a

--- a/bin/netdisco-rancid-export
+++ b/bin/netdisco-rancid-export
@@ -42,6 +42,9 @@ use Dancer::Plugin::DBIC 'schema';
 
 use App::Netdisco::Util::Permission ':all';
 
+# silent exit unless explicitly requested
+exit(0) unless setting('use_legacy_rancidexport');
+
 my $settings = setting( 'rancid' );
 my $domain_suffix = setting( 'domain_suffix' ) || '';
 my $delimiter = $settings->{ 'delimiter' } || ':';
@@ -117,7 +120,7 @@ foreach my $group (keys %$list) {
 
 =head1 NAME
 
-netdisco-rancid-export - Generate RANCID Group Configuration
+netdisco-rancid-export - DEPRECATED!
 
 =head1 DEPRECATED!
 

--- a/bin/netdisco-sshcollector
+++ b/bin/netdisco-sshcollector
@@ -193,7 +193,7 @@ Please read the deprecation notice if you are using C<netdisco-sshcollector>:
 
 =item *
 
-https://github.com/netdisco/netdisco/wiki/sshcollector-Deprecation
+L<https://github.com/netdisco/netdisco/wiki/sshcollector-Deprecation>
 
 =back
 

--- a/lib/App/Netdisco/Configuration.pm
+++ b/lib/App/Netdisco/Configuration.pm
@@ -85,7 +85,7 @@ if ((setting('snmp_auth') and 0 == scalar @{ setting('snmp_auth') })
   config->{'community_rw'} = [ @{setting('community_rw')}, 'private' ];
 }
 # fix up device_auth (or create it from old snmp_auth and community settings)
-# also imports legacy sshcollcetor config
+# also imports legacy sshcollector config
 config->{'device_auth'}
   = [ App::Netdisco::Util::DeviceAuth::fixup_device_auth() ];
 

--- a/lib/App/Netdisco/Worker/Plugin/MakeRancidConf.pm
+++ b/lib/App/Netdisco/Worker/Plugin/MakeRancidConf.pm
@@ -130,7 +130,11 @@ You could run this worker at 09:05 each day using the following configuration:
 
 Since MakeRancidConf is a worker module it can also be run via C<netdisco-do>:
 
- netdisco-do makerancidconf
+ ~/bin/netdisco-do makerancidconf
+
+Skipped devices and the reason for skipping them can be seen by using C<-D>:
+
+ ~/bin/netdisco-do makerancidconf -D
 
 =head1 CONFIGURATION
 
@@ -186,7 +190,7 @@ email config and creating the repository with C<rancid-cvs>.
 
 The location where the rancid configuration (F<rancid.types.base> and
 F<rancid.types.conf>) is installed. It will be used to check the existance
-of device types before exporting the devices to the rancid configuration. if no match
+of device types before exporting the devices to the rancid configuration. If no match
 is found the device will not be added to rancid.
 
 =head2 C<rancid_cvsroot>

--- a/share/config.yml
+++ b/share/config.yml
@@ -217,6 +217,7 @@ device_identity: []
 community: []
 community_rw: []
 device_auth: []
+use_legacy_rancidexport: false
 use_legacy_sshcollector: false
 get_credentials: ""
 bulkwalk_off: false

--- a/share/config.yml
+++ b/share/config.yml
@@ -352,6 +352,7 @@ schedule:
     when: '0 8,13,21 * * *'
   expire:
     when: '30 23 * * *'
+  makerancidconf: null
 
 job_prio:
   high:

--- a/share/environments/deployment.yml
+++ b/share/environments/deployment.yml
@@ -69,6 +69,7 @@ device_auth:
 #    when: '0 8,13,21 * * *'
 #  expire:
 #    when: '30 23 * * *'
+#  makerancidconf: null
 
 # number of SNMP workers to run in parallel (in netdisco-backend).
 # the default is twice the number of CPU cores. increase this if


### PR DESCRIPTION
* stop running bin/netdisco-rancid-export unless config use_legacy_rancidexport is set
* update makerancidconf manual a bit
* add makerancidconfig to default schedule but set to null
* 2 unrelated typo fixes
* document netdisco-do makerancidconf option