### PR TITLE
allow setting some speudo device  info

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Contact.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Contact.pm
@@ -16,22 +16,25 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
   my ($job, $workerconf) = @_;
   my ($device, $data) = map {$job->$_} qw/device extra/;
 
-  # snmp connect using rw community
-  my $snmp = App::Netdisco::Transport::SNMP->writer_for($device)
-    or return Status->defer("failed to connect to $device to update contact");
+  # update pseudo devices directly in database
+  unless ($device->is_pseudo()) {
+    # snmp connect using rw community
+    my $snmp = App::Netdisco::Transport::SNMP->writer_for($device)
+      or return Status->defer("failed to connect to $device to update contact");
 
-  my $rv = $snmp->set_contact($data);
+    my $rv = $snmp->set_contact($data);
 
-  if (!defined $rv) {
-    return Status->error(
-      "failed to set contact on $device: ". ($snmp->error || ''));
-  }
+    if (!defined $rv) {
+      return Status->error(
+        "failed to set contact on $device: ". ($snmp->error || ''));
+    }
 
-  # confirm the set happened
-  $snmp->clear_cache;
-  my $new_data = ($snmp->contact || '');
-  if ($new_data ne $data) {
-    return Status->error("verify of contact failed on $device: $new_data");
+    # confirm the set happened
+    $snmp->clear_cache;
+    my $new_data = ($snmp->contact || '');
+    if ($new_data ne $data) {
+      return Status->error("verify of contact failed on $device: $new_data");
+    }
   }
 
   # update netdisco DB

--- a/lib/App/Netdisco/Worker/Plugin/Location.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Location.pm
@@ -16,22 +16,25 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
   my ($job, $workerconf) = @_;
   my ($device, $data) = map {$job->$_} qw/device extra/;
 
-  # snmp connect using rw community
-  my $snmp = App::Netdisco::Transport::SNMP->writer_for($device)
-    or return Status->defer("failed to connect to $device to update location");
+  # update pseudo devices directly in database
+  unless ($device->is_pseudo()) {
+    # snmp connect using rw community
+    my $snmp = App::Netdisco::Transport::SNMP->writer_for($device)
+      or return Status->defer("failed to connect to $device to update location");
 
-  my $rv = $snmp->set_location($data);
+    my $rv = $snmp->set_location($data);
 
-  if (!defined $rv) {
-    return Status->error(
-      "failed to set location on $device: ". ($snmp->error || ''));
-  }
+    if (!defined $rv) {
+      return Status->error(
+        "failed to set location on $device: ". ($snmp->error || ''));
+    }
 
-  # confirm the set happened
-  $snmp->clear_cache;
-  my $new_data = ($snmp->location || '');
-  if ($new_data ne $data) {
-    return Status->error("verify of location failed on $device: $new_data");
+    # confirm the set happened
+    $snmp->clear_cache;
+    my $new_data = ($snmp->location || '');
+    if ($new_data ne $data) {
+      return Status->error("verify of location failed on $device: $new_data");
+    }
   }
 
   # update netdisco DB


### PR DESCRIPTION
allow setting of pseudo device port names (was added in 1f020e07ee0da9bb3a6deacbf690f0ec515d0e49 but somehow got lost?) while there, also allow setting of contact & location.

since this is done via the default job queue devices must be allowed to run actions (on by default , but see #561)