### PR TITLE
html template fixups

### DIFF
--- a/lib/App/Netdisco/Web/PortControl.pm
+++ b/lib/App/Netdisco/Web/PortControl.pm
@@ -31,14 +31,14 @@ ajax '/ajax/portcontrol' => require_any_role [qw(admin port_control)] => sub {
 
     schema('netdisco')->txn_do(sub {
       if (param('port')) {
-          my $a = "$action $subaction";
-          $a =~ s/-other$//;
-          $a =~ s/^portcontrol/port/;
+          my $act = "$action $subaction";
+          $act =~ s/-other$//;
+          $act =~ s/^portcontrol/port/;
 
           schema('netdisco')->resultset('DevicePortLog')->create({
             ip => param('device'),
             port => param('port'),
-            action => $a,
+            action => $act,
             username => session('logged_in_user'),
             userip => request->remote_address,
             reason => (param('reason') || 'other'),

--- a/share/public/css/netdisco.css
+++ b/share/public/css/netdisco.css
@@ -87,7 +87,7 @@ div.content > div.tab-content table.nd_floatinghead thead {
 
 /* to be added to qtip-bootstrap class */
 .nd_qtip-unconstrained {
-  min-width: none;
+  min-width: 0;
   max-width: none;
 }
 

--- a/share/views/ajax/admintask/nodemonitor.tt
+++ b/share/views/ajax/admintask/nodemonitor.tt
@@ -32,10 +32,10 @@
         <input data-form="update" name="mac" type="text" value="[% row.mac | html_entity %]">
       </td>
       <td class="nd_center-cell">
-        <input data-form="update" name="matchoui" type="checkbox" [% 'checked="checked"' IF row.matchoui %]>
+        <input data-form="update" name="matchoui" type="checkbox" [% ' checked="checked"' IF row.matchoui %]>
       </td>
       <td class="nd_center-cell">
-        <input data-form="update" name="active" type="checkbox" [% 'checked="checked"' IF row.active %]>
+        <input data-form="update" name="active" type="checkbox" [% ' checked="checked"' IF row.active %]>
       </td>
       <td class="nd_center-cell">
         <input data-form="update" name="why" type="text" value="[% row.why | html_entity %]">

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -43,13 +43,13 @@
         <input data-form="update" name="password" type="password" value="********">
       </td>
       <td class="nd_center-cell">
-        <input data-form="update" name="ldap" type="checkbox" [% 'checked="checked"' IF row.ldap %]>
+        <input data-form="update" name="ldap" type="checkbox" [% ' checked="checked"' IF row.ldap %]>
       </td>
       <td class="nd_center-cell">
-        <input data-form="update" name="port_control" type="checkbox" [% 'checked="checked"' IF row.port_control %]>
+        <input data-form="update" name="port_control" type="checkbox" [% ' checked="checked"' IF row.port_control %]>
       </td>
       <td class="nd_center-cell">
-        <input data-form="update" name="admin" type="checkbox" [% 'checked="checked"' IF row.admin %]>
+        <input data-form="update" name="admin" type="checkbox" [% ' checked="checked"' IF row.admin %]>
       </td>
       <td class="nd_center-cell">[% row.created   | html_entity %]</td>
       <td class="nd_center-cell">[% row.last_seen | html_entity %]</td>

--- a/share/views/sidebar/device/netmap.tt
+++ b/share/views/sidebar/device/netmap.tt
@@ -78,8 +78,8 @@
 
             [% IF hgroup_list.size %]
             <select class="nd_side-select" size="[% hgroup_list.size > 4 ? 4 : hgroup_list.size %]"
-              multiple="on" name="hgroup" id="nd_hgroup-select"
-              rel="tooltip" data-placement="left" data-offset="5" data-title="Host Groups"/>
+              multiple name="hgroup" id="nd_hgroup-select"
+              rel="tooltip" data-placement="left" data-offset="5" data-title="Host Groups">
               [% FOREACH opt IN hgroup_list.pairs %]
               <option[% ' selected="selected"' IF hgroup_lkp.exists(opt.key) %]
                 value="[% opt.key %]">[% opt.value | html_entity %]</option>
@@ -88,8 +88,8 @@
             [% END %]
             [% IF lgroup_list.size %]
             <select class="nd_side-select" size="[% lgroup_list.size > 4 ? 4 : lgroup_list.size %]"
-              multiple="on" name="lgroup" id="nd_lgroup-select"
-              rel="tooltip" data-placement="left" data-offset="5" data-title="Device Locations"/>
+              multiple name="lgroup" id="nd_lgroup-select"
+              rel="tooltip" data-placement="left" data-offset="5" data-title="Device Locations">
               [% FOREACH loc IN lgroup_list %]
               <option[% ' selected="selected"' IF lgroup_lkp.exists(loc) %]
                 value="[% loc %]">[% loc | html_entity %]</option>

--- a/share/views/sidebar/device/netmap.tt
+++ b/share/views/sidebar/device/netmap.tt
@@ -123,7 +123,7 @@
               <div class="clearfix input-prepend">
                 <label class="add-on">
                   <input type="checkbox" id="dynamicsize" name="dynamicsize"
-                    [% 'checked="checked"' IF vars.sidebar_defaults.device_netmap.dynamicsize %]/>
+                    [% ' checked="checked"' IF vars.sidebar_defaults.device_netmap.dynamicsize %]/>
                 </label>
                 <label class="nd_checkboxlabel" for="dynamicsize">
                   <span class="nd_searchcheckbox uneditable-input">Dynamic Size</span>

--- a/share/views/sidebar/device/netmap.tt
+++ b/share/views/sidebar/device/netmap.tt
@@ -13,7 +13,7 @@
               <div class="checkbox pull-left">
                 <label>
                   <input type="checkbox" name="showips" id="nd_showips"
-                    [% 'checked="checked"' IF vars.sidebar_defaults.device_netmap.showips %]
+                    [% ' checked="checked"' IF vars.sidebar_defaults.device_netmap.showips %]
                     data-toggle="toggle" data-size="small" data-width="30"
                     data-on="Show" data-off=" " data-onstyle="success">
                   <span onclick="$('#nd_showips').bootstrapToggle('toggle')">&nbsp;Management IP</span>
@@ -22,7 +22,7 @@
               <div class="checkbox pull-left">
                 <label>
                   <input type="checkbox" name="showspeed" id="nd_showspeed"
-                    [% 'checked="checked"' IF vars.sidebar_defaults.device_netmap.showspeed %]
+                    [% ' checked="checked"' IF vars.sidebar_defaults.device_netmap.showspeed %]
                     data-toggle="toggle" data-size="small" data-width="30"
                     data-on="Show" data-off=" " data-onstyle="success">
                   <span onclick="$('#nd_showspeed').bootstrapToggle('toggle')">&nbsp;Link Speed</span>

--- a/share/views/sidebar/device/ports.tt
+++ b/share/views/sidebar/device/ports.tt
@@ -126,7 +126,7 @@
                   <li>
                     <em class="muted">Show Ports with Status:</em><br/>
                     <div class="clearfix">
-                      <select id="nd_port-state-select" size="4" multiple="on" name="port_state"/>
+                      <select id="nd_port-state-select" size="4" multiple name="port_state">
                         <option selected="selected" value="up">Link Up</option>
                         <option selected="selected" value="free">Port Free</option>
                         <option selected="selected" value="down">Link Down</option>

--- a/share/views/sidebar/report/moduleinventory.tt
+++ b/share/views/sidebar/report/moduleinventory.tt
@@ -44,8 +44,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select nd_colored-input" size="[% class_list.size > 5 ? 5 : class_list.size %]"
-                multiple="on" name="class"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Module Class"/>
+                multiple name="class"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Module Class">
                 [% FOREACH opt IN class_list %]
                 <option[% ' selected="selected"' IF class_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]

--- a/share/views/sidebar/report/netbios.tt
+++ b/share/views/sidebar/report/netbios.tt
@@ -2,8 +2,8 @@
             <p class="nd_sidebar-title"><em>NetBIOS Domain</em></p>
             <div class="clearfix">
               <select class="nd_side-select nd_colored-input" size="[% domain_list.size > 8 ? 8 : domain_list.size %]"
-                multiple="on" name="domain"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Domain"/>
+                multiple name="domain"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Domain">
                 [% FOREACH opt IN domain_list %]
                   [% UNLESS opt == '' %]
                     <option[% ' selected="selected"' IF domain_lkp.exists(opt) %]>[% opt | html_entity %]</option>

--- a/share/views/sidebar/report/nodesdiscovered.tt
+++ b/share/views/sidebar/report/nodesdiscovered.tt
@@ -13,8 +13,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select nd_colored-input" size="[% type_list.size > 8 ? 8 : type_list.size %]"
-                multiple="on" name="remote_type"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Remote Type"/>
+                multiple name="remote_type"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Remote Type">
                 [% FOREACH opt IN type_list %]
                     <option[% ' selected="selected"' IF type_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]

--- a/share/views/sidebar/report/nodevendor.tt
+++ b/share/views/sidebar/report/nodevendor.tt
@@ -6,8 +6,8 @@
               </legend>
               <div class="clearfix">
                 <select class="nd_side-select nd_colored-input" size="[% vendor_list.size > 8 ? 8 : vendor_list.size %]"
-                  multiple="on" name="vendor"
-                  rel="tooltip" data-placement="left" data-offset="5" data-title="Vendor"/>
+                  multiple name="vendor"
+                  rel="tooltip" data-placement="left" data-offset="5" data-title="Vendor">
                   [% FOREACH opt IN vendor_list %]
                     [% UNLESS opt == '' %]
                       <option[% ' selected="selected"' IF vendor_lkp.exists(opt) %]>[% opt | html_entity %]</option>

--- a/share/views/sidebar/report/portssid.tt
+++ b/share/views/sidebar/report/portssid.tt
@@ -2,8 +2,8 @@
             <p class="nd_sidebar-title"><em>Details by SSID</em></p>
             <div class="clearfix">
               <select class="nd_side-select nd_colored-input" size="[% ssid_list.size > 8 ? 8 : ssid_list.size %]"
-                multiple="on" name="ssid"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="SSID"/>
+                multiple name="ssid"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="SSID">
                 [% FOREACH opt IN ssid_list %]
                     <option[% ' selected="selected"' IF ssid_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]

--- a/share/views/sidebar/search/device.tt
+++ b/share/views/sidebar/search/device.tt
@@ -43,8 +43,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select" size="[% model_list.size > 5 ? 5 : model_list.size %]"
-                multiple="on" name="model"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Model"/>
+                multiple name="model"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Model">
                 [% FOREACH opt IN model_list %]
                 <option[% ' selected="selected"' IF model_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]
@@ -52,8 +52,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select" size="[% os_list.size > 5 ? 5 : os_list.size %]"
-                multiple="on" name="os"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Operating System"/>
+                multiple name="os"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Operating System">
                 [% FOREACH opt IN os_list %]
                 <option[% ' selected="selected"' IF os_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]
@@ -61,8 +61,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select" size="[% os_ver_list.size > 5 ? 5 : os_ver_list.size %]"
-                multiple="on" name="os_ver"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="OS Release"/>
+                multiple name="os_ver"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="OS Release">
                 [% FOREACH opt IN os_ver_list %]
                 <option[% ' selected="selected"' IF os_ver_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]
@@ -70,8 +70,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select" size="[% vendor_list.size > 5 ? 5 : vendor_list.size %]"
-                multiple="on" name="vendor"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Vendor"/>
+                multiple name="vendor"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Vendor">
                 [% FOREACH opt IN vendor_list %]
                 <option[% ' selected="selected"' IF vendor_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]
@@ -79,8 +79,8 @@
             </div>
             <div class="clearfix">
               <select class="nd_side-select" size="3"
-                multiple="on" name="layers"
-                rel="tooltip" data-placement="left" data-offset="5" data-title="Layer"/>
+                multiple name="layers"
+                rel="tooltip" data-placement="left" data-offset="5" data-title="Layer">
                 [% FOREACH opt IN [ 1 .. 7 ] %]
                 <option[% ' selected="selected"' IF layers_lkp.exists(opt) %]>[% opt | html_entity %]</option>
                 [% END %]


### PR DESCRIPTION
mostly select tags which were closed (had a / at the end) before the options were included and tt statements which were missing a space in front of their output string.

also change one use of $a to any other variable name, see https://perldoc.perl.org/perlvar.html#SPECIAL-VARIABLES for that.

finally changed 1 css attribute min-width from none to 0, none is not allowed it seems.

all of these were found with intellij idea ultimate from jetbrains: https://www.jetbrains.com/idea/
they were kind enough to validate netdisco & snmp::info as worthy open source projects, so you can get a free license for all their products, as long as you don't use it on any commercial or otherwise for profit projects.