### PR TITLE
make sidebar tiny bit wider

### DIFF
--- a/share/public/css/netdisco.css
+++ b/share/public/css/netdisco.css
@@ -359,7 +359,7 @@ td > form.nd_inline-form {
 .container-fluid > .nd_sidebar {
   position: absolute;
   right: 20px;
-  width: 200px;
+  width: 205px;
   left: auto;
 }
 


### PR DESCRIPTION
a4d4bf7f339ffc31bacf8359ebbbe85462984f46
"wireless access point" wraps, make sidebar 5px wider to make it not wrap