### PR TITLE
Allow to use a special identity file to connect to device in SSH

### DIFF
--- a/lib/App/Netdisco/Transport/SSH.pm
+++ b/lib/App/Netdisco/Transport/SSH.pm
@@ -79,6 +79,8 @@ sub session_for {
     $device->ip,
     user => $auth->{username},
     password => $auth->{password},
+    key_path => $auth->{identity_file},
+    passphrase => $auth->{identity_pass},
     timeout => 30,
     async => 0,
     default_stderr_file => '/dev/null',


### PR DESCRIPTION
For the SSH collector, we cannot specify a specific identity file for SSH.
With this, we can indicate an identity file and a passphrase for the.

Bellow the key to add to a "device_auth" block:
- identity_file: to indicate an identity file
- identity_pass: to indicate the passphrase for this file

Just a question: i din't havce found if the mac page for App::Netdisco::Manual::Configuration is generated. Did I need to update it ? If yes, where is located the file that generate the man page?