### PR TITLE
Add DOCSIS/Cable Modem Discovery

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors/DOCSIS.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors/DOCSIS.pm
@@ -39,7 +39,7 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
 
     $count++;
     vars->{'queued'}->{$ip} += 1;
-    debug sprintf ' [%s] queue - queued %s for discovery (peer)', $device, $ip;
+    debug sprintf ' [%s] queue - queued %s for discovery (DOCSIS peer)', $device, $ip;
   }
 
   return Status->info(" [$device] neigh - $count DOCSIS peers (modems) added to queue.");

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors/DOCSIS.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors/DOCSIS.pm
@@ -1,0 +1,48 @@
+package App::Netdisco::Worker::Plugin::Discover::Neighbors::DOCSIS;
+use Dancer ':syntax';
+
+use App::Netdisco::Worker::Plugin;
+use App::Netdisco::Transport::SNMP;
+use aliased 'App::Netdisco::Worker::Status';
+
+use App::Netdisco::Util::Device qw/get_device is_discoverable/;
+use App::Netdisco::JobQueue 'jq_insert';
+
+register_worker({ phase => 'main', driver => 'snmp' }, sub {
+  my ($job, $workerconf) = @_;
+
+  my $device = $job->device;
+  return unless $device->in_storage;
+  my $snmp = App::Netdisco::Transport::SNMP->reader_for($device)
+    or return Status->defer("discover failed: could not SNMP connect to $device");
+
+  my $modems = $snmp->docs_if_cmts_cm_status_inet_address() || {};
+
+  return Status->info(" [$device] neigh - no modems (not a DOCSIS device?)")
+    unless (scalar values %$modems);
+
+  my $count = 0;
+  foreach my $ip (values %$modems) { 
+
+    # Some modems may be registered, but not have an IP assigned (they could be offline, disabled, etc)
+    next if $ip eq '';
+
+    my $peer = get_device($ip);
+    next if $peer->in_storage or not is_discoverable($peer);
+    next if vars->{'queued'}->{$ip};
+
+    jq_insert({
+      device => $ip,
+      action => 'discover',
+      subaction => 'with-nodes',
+    });
+
+    $count++;
+    vars->{'queued'}->{$ip} += 1;
+    debug sprintf ' [%s] queue - queued %s for discovery (peer)', $device, $ip;
+  }
+
+  return Status->info(" [$device] neigh - $count peers added to queue.");
+});
+
+true;

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors/DOCSIS.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors/DOCSIS.pm
@@ -18,7 +18,7 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
 
   my $modems = $snmp->docs_if_cmts_cm_status_inet_address() || {};
 
-  return Status->info(" [$device] neigh - no modems (not a DOCSIS device?)")
+  return Status->info(" [$device] neigh - no modems (probably not a DOCSIS device)")
     unless (scalar values %$modems);
 
   my $count = 0;
@@ -42,7 +42,7 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
     debug sprintf ' [%s] queue - queued %s for discovery (peer)', $device, $ip;
   }
 
-  return Status->info(" [$device] neigh - $count peers added to queue.");
+  return Status->info(" [$device] neigh - $count DOCSIS peers (modems) added to queue.");
 });
 
 true;

--- a/share/config.yml
+++ b/share/config.yml
@@ -386,6 +386,7 @@ worker_plugins:
   - 'Discover::Entities'
   - 'Discover::Neighbors'
   - 'Discover::Neighbors::Routed'
+  - 'Discover::Neighbors::DOCSIS'
   - 'Discover::PortPower'
   - 'Discover::PortProperties'
   - 'Discover::Properties'


### PR DESCRIPTION
Adds discovery capability of DOCSIS (Cable) modems off a headend. Uses generic DOCSIS MIBs supported in SNMP::Info.
Works with my infrastructure, but ARRIS and Motorola (and other vendor) modems may require additional MIBs or processing to correctly determine models. 