### PR TITLE
Reduce macsuck bandwidth usage to database

### DIFF
--- a/lib/App/Netdisco/Util/PortMAC.pm
+++ b/lib/App/Netdisco/Util/PortMAC.pm
@@ -5,7 +5,7 @@ use Dancer::Plugin::DBIC 'schema';
 
 use base 'Exporter';
 our @EXPORT = ();
-our @EXPORT_OK = qw/ get_port_macs  /;
+our @EXPORT_OK = qw/ get_port_macs /;
 our %EXPORT_TAGS = (all => \@EXPORT_OK);
 
 =head1 NAME
@@ -32,7 +32,6 @@ sub get_port_macs {
 
     my ($fw_mac_list) = @_;
     my $port_macs = {};
-    
 
     my $dp_macs
         = schema('netdisco')->resultset('DevicePort')

--- a/lib/App/Netdisco/Worker/Plugin/Macsuck/Nodes.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Macsuck/Nodes.pm
@@ -278,8 +278,7 @@ sub walk_fwtable {
     ? {} : $snmp->qb_fw_vlan;
   my $bp_index = $snmp->bp_index;
 
-  my @fw_mac_list = values %$fw_mac; 
-
+  my @fw_mac_list = values %$fw_mac;
   my $port_macs = get_port_macs(\@fw_mac_list);
 
   # to map forwarding table port to device port we have

--- a/lib/App/Netdisco/Worker/Plugin/Macsuck/Nodes.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Macsuck/Nodes.pm
@@ -13,7 +13,6 @@ use App::Netdisco::Util::SNMP 'snmp_comm_reindex';
 use Dancer::Plugin::DBIC 'schema';
 use Time::HiRes 'gettimeofday';
 use Scope::Guard 'guard';
-use Data::Dumper;
 
 register_worker({ phase => 'main', driver => 'snmp' }, sub {
   my ($job, $workerconf) = @_;


### PR DESCRIPTION
From IRC today:

    19:31 < rc9000> hi guys! some days ago our db cluster switched my postgres instance 
                    to the backup dc, but netdisco remained at the main dc.
    19:31 < rc9000> a little later I got complaints that I was using about 400mbit/s of 
                    the already highly saturated link
    19:32 < rc9000> it turns out that get_port_macs queries a full list of all device_port 
                    ips and macs, which is about 13MB in our case
    19:33 < rc9000> and we poll 9000ish devices in 40 minutes, so the math works out :) 
    19:34 < rc9000> i'm looking at the code and it seems i could make a slightly more specific 
                    get_port_macs inside walk_fwtable, that contains only the macs really 
                    returned from snmp->fw_mac

This PR tries to fix the above with a get_port_macs that's called inside walk_fwtable and only returns the macs found in the current target device/vlan.

If I'm reading walk_fwtable right the only lookups that can ever be made are for macs that the current snmp->fw_mac contains, but I'd appreciate if @ollyg and other cracks could verify this assumption. Also, I did not find usages of get_port_macs outside of Macsuck/Nodes.pm, so I hope this doesn't break anything.

I'm trying it now in our environment and it both seems to work ok so far and has reduced bandwidth DB -> poller by orders of magnitude.