### PR TITLE
Allow <"> in remote_port

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors.pm
@@ -262,7 +262,7 @@ sub store_neighbors {
       $remote_port = $c_port->{$entry};
       if (defined $remote_port) {
           # clean weird characters
-          $remote_port =~ s/[^\d\s\/\.,()\w:-]+//gi;
+          $remote_port =~ s/[^\d\s\/\.,"()\w:-]+//gi;
       }
       else {
           debug sprintf ' [%s] neigh - no remote port found for port %s at %s',


### PR DESCRIPTION
Is it ok if we remove <"> from the "weird characters" in Neighbors.pm? Background is that the remote_port from Nokia TiMOS (the former Alcatel-Lucent brand devices) looks like this: 

    6/2/13, 10/100/Gig Ethernet SFP, "the descrption the user entered"

Not removing the <"> makes the device_port.remote_port match the matching device_port.descr, and also makes the "Connected devices" link in the Web UI work. I found no adverse effects.