### PR TITLE
Change the way to retrieve IP address of interfaces

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -424,6 +424,7 @@ sub _get_ipv4_aliases {
   my @aliases;
 
   my $ip_index   = $snmp->ip_index;
+  my $ip_table   = $snmp->ip_table;
   my $interfaces = $snmp->interfaces;
   my $ip_netmask = $snmp->ip_netmask;
 
@@ -434,6 +435,7 @@ sub _get_ipv4_aliases {
     foreach my $vrf (@vrf_list) {
       snmp_comm_reindex($snmp, $device, $vrf);
       $ip_index   = { %$ip_index,   %{$snmp->ip_index}   };
+      $ip_table   = { %$ip_table,   %{$snmp->ip_table}   };
       $interfaces = { %$interfaces, %{$snmp->interfaces} };
       $ip_netmask = { %$ip_netmask, %{$snmp->ip_netmask} };
     }
@@ -441,7 +443,7 @@ sub _get_ipv4_aliases {
 
   # build device aliases suitable for DBIC
   foreach my $entry (keys %$ip_index) {
-      my $ip = NetAddr::IP::Lite->new($entry)
+      my $ip = NetAddr::IP::Lite->new($ip_table->{$entry}) || NetAddr::IP::Lite->new($entry)
         or next;
       my $addr = $ip->addr;
 
@@ -449,10 +451,10 @@ sub _get_ipv4_aliases {
       next if check_acl_no($ip, 'group:__LOOPBACK_ADDRESSES__');
       next if setting('ignore_private_nets') and $ip->is_rfc1918;
 
-      my $iid = $ip_index->{$addr};
+      my $iid = $ip_index->{$entry};
       my $port = $interfaces->{$iid};
-      my $subnet = $ip_netmask->{$addr}
-        ? NetAddr::IP::Lite->new($addr, $ip_netmask->{$addr})->network->cidr
+      my $subnet = $ip_netmask->{$entry}
+        ? NetAddr::IP::Lite->new($addr, $ip_netmask->{$entry})->network->cidr
         : undef;
 
       debug sprintf ' [%s] device - aliased as %s', $device->ip, $addr;


### PR DESCRIPTION
Use by default the ipTable MIB entry to retrieve the IP address of interfaces and fallback to the index method as previously. 
Fixe the issue with the case where the index is not really an IP address (seen in Fortinet with VDOM).

Related to issue #1016