### PR TITLE
Add indexes for custom_fields in device + device_port

### DIFF
--- a/lib/App/Netdisco/DB.pm
+++ b/lib/App/Netdisco/DB.pm
@@ -11,7 +11,7 @@ __PACKAGE__->load_namespaces(
 );
 
 our # try to hide from kwalitee
-  $VERSION = 78; # schema version used for upgrades, keep as integer
+  $VERSION = 79; # schema version used for upgrades, keep as integer
 
 use Path::Class;
 use File::ShareDir 'dist_dir';

--- a/share/schema_versions/App-Netdisco-DB-78-79-PostgreSQL.sql
+++ b/share/schema_versions/App-Netdisco-DB-78-79-PostgreSQL.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+CREATE INDEX idx_device_custom_fields ON device USING gin (custom_fields);
+CREATE INDEX idx_device_port_custom_fields ON device_port USING gin (custom_fields);
+
+COMMIT;


### PR DESCRIPTION
Hello @ollyg & team. We've put quite a bunch of additional attributes into custom_fields. Works great but got a bit slow, could we add these indexes to speed up various jsonb operations?

This requires GIN and the jsonb_ops, AFAICT this should work in 9.6 already: https://www.postgresql.org/docs/9.6/gin-builtin-opclasses.html - but I've only tried it in >= 12