### PR TITLE
Fix an error when the log string is empty

### DIFF
--- a/lib/App/Netdisco/JobQueue/PostgreSQL.pm
+++ b/lib/App/Netdisco/JobQueue/PostgreSQL.pm
@@ -279,7 +279,7 @@ sub jq_complete {
         ->search({ job => $job->id }, { for => 'update' })
         ->update({
           status => $job->status,
-          log    => $job->log,
+          log    => (ref($job->log) eq ref('')) ? $job->log : '',
           started  => $job->started,
           finished => $job->finished,
           (($job->action eq 'hook') ? (subaction => $job->subaction) : ()),


### PR DESCRIPTION
Related to the incident #993

Concerning the error message `error bless( {'msg' => 'DBIx::Class::SQLMaker::ClassicExtensions::puke(): Fatal: Operator calls in update must be in the form { -op => $arg } at /home/netdisco/perl5/lib/perl5/App/Netdisco/JobQueue/PostgreSQL.pm line 282
'}, 'DBIx::Class::Exception' )`.

I suspect that, sometime, the log is not defined and so, the function failed:
When it's work:
```
DEBUG: id=$VAR1 = 8680630;
 | status=$VAR1 = 'done';
 | log=$VAR1 = 'Ended macsuck for 10.208.232.13';
 | started=$VAR1 = 'Fri Jun 30 15:32:32 2023';
 | finished=$VAR1 = 'Fri Jun 30 15:33:28 2023';
 | action=$VAR1 = 'macsuck';
 | subaction=$VAR1 = '';
 | only_namespace=$VAR1 = undef;
 | obj=$VAR1 = {
          'log' => 'Ended macsuck for 10.208.232.13',
          'status' => 'done',
          'finished' => 'Fri Jun 30 15:33:28 2023',
          'started' => 'Fri Jun 30 15:32:32 2023'
        };
```

When we have the error:
```
Use of uninitialized value $op in pattern match (m//) at /opt/netdisco/perl5/lib/perl5/SQL/Abstract/Classic.pm line 327.
DEBUG: id=$VAR1 = 8680660;
 | status=$VAR1 = 'error';
 | log=$VAR1 = {};
 | started=$VAR1 = 'Fri Jun 30 15:30:53 2023';
 | finished=$VAR1 = 'Fri Jun 30 15:40:53 2023';
 | action=$VAR1 = 'macsuck';
 | subaction=$VAR1 = '';
 | only_namespace=$VAR1 = undef;
 | obj=$VAR1 = {
          'finished' => 'Fri Jun 30 15:40:53 2023',
          'status' => 'error',
          'started' => 'Fri Jun 30 15:30:53 2023',
          'log' => {}
        };

[250327] 2023-06-30 13:40:53 error bless( {'msg' => 'DBIx::Class::SQLMaker::ClassicExtensions::puke(): Fatal: Operator calls in update must be in the form { -op => $arg } at /opt/netdisco/perl5/lib/perl5/App/Netdisco/JobQueue/PostgreSQL.pm line 280
'}, 'DBIx::Class::Exception' )
```