### PR TITLE
add support for custom radius VSAs for Access-Request

### DIFF
--- a/lib/App/Netdisco/Configuration.pm
+++ b/lib/App/Netdisco/Configuration.pm
@@ -211,18 +211,7 @@ else {
   config->{'domain_suffix'} = qr//;
 }
 
-# convert radius and tacacs from single to lists
-
-if (ref {} eq ref setting('radius')
-  and exists setting('radius')->{'secret'}) {
-
-  my $servers = (ref [] eq ref setting('radius')->{'server'}
-    ? setting('radius')->{'server'} : [setting('radius')->{'server'}]);
-  config->{'radius'} = [
-    Secret => setting('radius')->{'secret'},
-    NodeList => $servers,
-  ];
-}
+# convert tacacs from single to lists
 
 if (ref {} eq ref setting('tacacs')
   and exists setting('tacacs')->{'key'}) {


### PR DESCRIPTION
This PR adds support for setting an optional timeout and adding optional Vendor-Specific Attributes (VSA) to an auth request.

For the timeout the config would look like:
```yaml
radius:
  server: radius00.example.net
  secret: mYsecRet
  timeout: 30
```
The timeout is useful when 2FA is being used and additional time is required. The default is set to 15 sec.

For the VSAs the config would look like:
```yaml
radius:
  server: radius00.example.net
  secret: mYsecRet
  vsa:
    - name: Class
       value: Netdisco
    - name: 101
       value: Netdisco
       type: string
       vendor: 123
```
Adding VSA(s) is useful to route and classify auth requests to handle differently on radius backends.

I removed the 'h323-return-code' and 'Digest-Attributes' attributes as I don't see why those are being sent other than they were in the Authen::Radius documentation example.

I moved the munging of the radius config from Configuration.pm to DBIC.pm as I needed the additional settings that don't get put into Authen::Radius->new().

Let me know if there are any changes needed or discussion.
Thanks for the consideration.