### PR TITLE
Fix a potential error with undefined value in Transport/SNMP.pm

### DIFF
--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -216,11 +216,13 @@ sub _snmp_connect_generic {
           # if successful, restore the default/user timeouts and return
           if ($info) {
               my $class = ($useclass ? $classes[0] : $info->device_type);
-              return $class->new(
-                %snmp_args, Version => $ver,
-                ($info->offline ? (Cache => $info->cache) : ()),
-                _mk_info_commargs($comm),
-              );
+              if (defined $class && eval { $class->can("new") }) {
+                  return $class->new(
+                    %snmp_args, Version => $ver,
+                    ($info->offline ? (Cache => $info->cache) : ()),
+                    _mk_info_commargs($comm),
+                  );
+              }
           }
       }
   }


### PR DESCRIPTION
Sometimes, I can see in the job queue that some jobs are in a wrong format because we try to call a new method to an undefined object
![image](https://github.com/netdisco/netdisco/assets/2353530/7f445000-9b71-4b75-a83d-6d00ae20b630)

I suspect that for an unknown reason, sometimes, the $class variable is undefined...

So, I have added a test to validate that the object is defined prior to call the new method