### PR TITLE
Fix an issue when you try to search a false MAC

### DIFF
--- a/lib/App/Netdisco/DB/ResultSet/Device.pm
+++ b/lib/App/Netdisco/DB/ResultSet/Device.pm
@@ -295,7 +295,7 @@ sub search_by_field {
     undef $mac if
       ($mac and $mac->as_ieee
       and (($mac->as_ieee eq '00:00:00:00:00:00')
-        or ($mac->as_ieee !~ m/$RE{net}{MAC}/)));
+        or ($mac->as_ieee !~ m/^$RE{net}{MAC}$/)));
 
     my @joins = (
       ($mac ? qw/ports/ : ()),
@@ -417,7 +417,7 @@ sub search_fuzzy {
     undef $mac if
       ($mac and $mac->as_ieee
       and (($mac->as_ieee eq '00:00:00:00:00:00')
-        or ($mac->as_ieee !~ m/$RE{net}{MAC}/)));
+        or ($mac->as_ieee !~ m/^$RE{net}{MAC}$/)));
     $mac = ($mac ? $mac->as_ieee : $q);
 
     return $rs->ports_with_mac($mac)

--- a/lib/App/Netdisco/Web/Plugin/Search/Node.pm
+++ b/lib/App/Netdisco/Web/Plugin/Search/Node.pm
@@ -74,7 +74,7 @@ get '/ajax/content/search/node' => require_login sub {
     undef $mac if
       ($mac and $mac->as_ieee
       and (($mac->as_ieee eq '00:00:00:00:00:00')
-        or ($mac->as_ieee !~ m/$RE{net}{MAC}/)));
+        or ($mac->as_ieee !~ m/^$RE{net}{MAC}$/)));
 
     my @active = (param('archived') ? () : (-bool => 'active'));
     my (@times, @wifitimes, @porttimes);

--- a/lib/App/Netdisco/Web/Plugin/Search/Port.pm
+++ b/lib/App/Netdisco/Web/Plugin/Search/Port.pm
@@ -73,7 +73,7 @@ get '/ajax/content/search/port' => require_login sub {
         undef $mac if
           ($mac and $mac->as_ieee
           and (($mac->as_ieee eq '00:00:00:00:00:00')
-            or ($mac->as_ieee !~ m/$RE{net}{MAC}/)));
+            or ($mac->as_ieee !~ m/^$RE{net}{MAC}$/)));
 
         $rs = schema(vars->{'tenant'})->resultset('DevicePort')
                                 ->columns( [qw/ ip port name up up_admin speed /] )

--- a/lib/App/Netdisco/Web/Search.pm
+++ b/lib/App/Netdisco/Web/Search.pm
@@ -43,7 +43,7 @@ get '/search' => require_login sub {
             undef $mac if
               ($mac and $mac->as_ieee
               and (($mac->as_ieee eq '00:00:00:00:00:00')
-                or ($mac->as_ieee !~ m/$RE{net}{MAC}/)));
+                or ($mac->as_ieee !~ m/^$RE{net}{MAC}$/)));
 
             if ($nd and $nd->count) {
                 if ($nd->count == 1) {


### PR DESCRIPTION
Currently, when you search a false MAC address like `e2:62:a3:31:5e:734` or `ae2:62:a3:31:5e:73`, you receive an error 500.
So, a simple fix to filter correctly when the MAC address is bad.

But, I think a better solution should be send back an error message in WebUI to indicate that the MAC address is wrong...