### PR TITLE
ping sweep utility worker to enqueue discover jobs from an IP prefix

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -66,6 +66,8 @@ Module::Build->new(
     'Net::DNS' => '0.72',
     'Net::LDAP' => '0',
     'Net::OpenSSH' => '0',
+    'Net::Ping' => '0', # is core
+    'Net::Ping::External' => '0',
     'NetAddr::MAC' => '0.93',
     'NetAddr::IP' => '4.068',
     'Opcode' => '1.07',

--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -123,7 +123,10 @@ sub _test_and_resolve_device {
 }
 
 foreach my $device (@$devices) {
-  if (-f $device) {
+  if ($action eq 'pingsweep') {
+      push @hostlist, $device;
+  }
+  elsif (-f $device) {
       debug sprintf 'opening file for reading hosts/IPs: %s', $device;
       my @dlist = read_lines $device;
 
@@ -155,7 +158,7 @@ if (not $force and scalar @hostlist > 512) {
 foreach my $host (@hostlist) {
   push @job_specs, {
     action => $action,
-    device => $host ? $host->addr : undef,
+    device => ref $host ? $host->addr : $host,
     port   => $port,
     subaction => ($extra || (($action eq 'discover') ? 'with-nodes' : undef)),
     username => ($ENV{USER} || 'netdisco-do'),

--- a/lib/App/Netdisco/Web/AdminTask.pm
+++ b/lib/App/Netdisco/Web/AdminTask.pm
@@ -17,10 +17,11 @@ sub add_job {
       ($device and (!$net or $net->num == 0 or $net->addr eq '0.0.0.0'));
 
     my @hostlist = $device ? ($net->hostenum) : (undef);
+    @hostlist = ($device) if $action eq 'pingsweep';
 
     my $happy = jq_insert([map {{
       action => $action,
-      ($_     ? (device => $_->addr) : ()),
+      ($_     ? (device => ($action eq 'pingsweep' ? $_ : $_->addr)) : ()),
       ($port  ? (port   => $port)    : ()),
       ($extra ? (extra  => $extra)   : ()),
       username => session('logged_in_user'),
@@ -35,7 +36,7 @@ sub add_job {
         schema(vars->{'tenant'})->resultset('UserLog')->create({
           username => session('logged_in_user'),
           userip => scalar eval {request->remote_address},
-          event => (sprintf $msg, $h->addr),
+          event => (sprintf $msg, ($action eq 'pingsweep' ? $h : $h->addr)),
           details => ($extra || 'no user log supplied'),
         });
     }

--- a/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
+++ b/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
@@ -25,7 +25,7 @@ register_worker({ phase => 'main' }, sub {
         sprintf 'unable to understand as host, IP, or prefix: %s', $targets)
   }
 
-  my @job_specs = ();
+  my $job_count = 0;
   my $ping = Net::Ping->new({proto => 'external'});
 
   my $pinger = sub {
@@ -43,17 +43,18 @@ register_worker({ phase => 'main' }, sub {
       next;
     }
 
-    push @job_specs, {
+    jq_insert([{
       action => 'discover',
       device => $host,
       subaction => 'with-nodes',
       username => ($ENV{USER} || 'netdisco-do'),
-    };
+    }]);
+
+    ++$job_count;
   }
 
-  jq_insert( \@job_specs );
   return Status->done(sprintf
-    'Finished ping sweep: queued %s jobs from %s hosts', (scalar @job_specs), $net->num());
+    'Finished ping sweep: queued %s jobs from %s hosts', $job_count, $net->num());
 });
 
 true;

--- a/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
+++ b/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
@@ -14,8 +14,8 @@ use NetAddr::IP qw/:rfc3021 :lower/;
 
 register_worker({ phase => 'main' }, sub {
   my ($job, $workerconf) = @_;
-  my $targets = $job->port
-    or return Status->error('missing parameter -p/port with IP prefix');
+  my $targets = $job->device
+    or return Status->error('missing parameter -d/device with IP prefix');
 
   my $timeout = $job->extra || '0.1';
 

--- a/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
+++ b/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
@@ -1,0 +1,59 @@
+package App::Netdisco::Worker::Plugin::PingSweep;
+
+use Dancer ':syntax';
+use App::Netdisco::Worker::Plugin;
+use aliased 'App::Netdisco::Worker::Status';
+
+use App::Netdisco::JobQueue 'jq_insert';
+
+use Time::HiRes;
+use Sys::SigAction 'timeout_call';
+use Net::Ping;
+use Net::Ping::External;
+use NetAddr::IP;
+
+register_worker({ phase => 'main' }, sub {
+  my ($job, $workerconf) = @_;
+  my $extra = $job->extra
+    or return Status->error('missing parameter -e/extra/subaction with IP prefix');
+
+  my $net = NetAddr::IP->new($extra);
+  if (!$net or $net->num == 0 or $net->addr eq '0.0.0.0') {
+      return Status->error(
+        sprintf 'unable to understand as host, IP, or prefix: %s', $extra)
+  }
+
+  my @job_specs = ();
+  my $ping = Net::Ping->new({proto => 'external'});
+
+  my $pinger = sub {
+    my $host = shift;
+    $ping->ping($host);
+    debug sprintf 'pinged %s successfully', $host;
+  };
+
+  foreach my $idx (0 .. $net->num()) {
+    my $addr = $net->nth($idx) or next;
+    my $host = $addr->addr;
+
+    if (timeout_call('0.2', $pinger, $host)) {
+      debug sprintf 'pinged %s and timed out', $host;
+      next;
+    }
+
+    push @job_specs, {
+      action => 'discover',
+      device => $host,
+      subaction => 'with-nodes',
+      username => ($ENV{USER} || 'netdisco-do'),
+    };
+  }
+
+  jq_insert( \@job_specs );
+  debug sprintf 'pingsweep: queued %s jobs from %s hosts',
+    (scalar @job_specs), $net->num();
+
+  return Status->done('Finished ping sweep');
+});
+
+true;

--- a/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
+++ b/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
@@ -52,10 +52,8 @@ register_worker({ phase => 'main' }, sub {
   }
 
   jq_insert( \@job_specs );
-  debug sprintf 'pingsweep: queued %s jobs from %s hosts',
-    (scalar @job_specs), $net->num();
-
-  return Status->done('Finished ping sweep');
+  return Status->done(sprintf
+    'Finished ping sweep: queued %s jobs from %s hosts', (scalar @job_specs), $net->num());
 });
 
 true;

--- a/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
+++ b/lib/App/Netdisco/Worker/Plugin/PingSweep.pm
@@ -10,7 +10,7 @@ use Time::HiRes;
 use Sys::SigAction 'timeout_call';
 use Net::Ping;
 use Net::Ping::External;
-use NetAddr::IP;
+use NetAddr::IP qw/:rfc3021 :lower/;
 
 register_worker({ phase => 'main' }, sub {
   my ($job, $workerconf) = @_;

--- a/share/config.yml
+++ b/share/config.yml
@@ -645,6 +645,7 @@ job_prio:
     - 'arpwalk'
     - 'discover'
     - 'discoverall'
+    - 'pingsweep'
     - 'expire'
     - 'macsuck'
     - 'macwalk'

--- a/share/config.yml
+++ b/share/config.yml
@@ -702,6 +702,7 @@ worker_plugins:
   - 'Nbtstat::Core'
   - 'Nbtwalk'
   - 'NodeMonitor'
+  - 'PingSweep'
   - 'PortControl'
   - 'PortName'
   - 'Power'

--- a/share/config.yml
+++ b/share/config.yml
@@ -600,6 +600,7 @@ workers:
 # this one takes ages
 snapshot_timeout: 1200
 primeskiplist_timeout: 1200
+pingsweep_timeout: 7200
 
 # 50 minutes
 jobs_stale_after: 3000

--- a/share/views/ajax/device/addresses.tt
+++ b/share/views/ajax/device/addresses.tt
@@ -42,7 +42,8 @@ $(document).ready(function() {
       }, {
         "data": 'subnet',
         "render": function(data, type, row, meta) {
-          return '<a href="[% search_device | none %]&q=' + encodeURIComponent(data) + '&ip=' + encodeURIComponent(data) + '">' + he.encode(data || '') + '</a>';
+          return '[% IF user_has_role('admin') %]<a class="nd_stealth-link nd_node-ext-link" href="[% uri_base | none %]/?sweep=' + encodeURIComponent(data) + '"><i class="icon-search"></i></a>&nbsp;[% END %]'
+            + '<a href="[% search_device | none %]&q=' + encodeURIComponent(data) + '&ip=' + encodeURIComponent(data) + '">' + he.encode(data || '') + '</a>';
         }
       }
     ],

--- a/share/views/index.tt
+++ b/share/views/index.tt
@@ -79,7 +79,7 @@
           </form>
           <form class="nd_login-form" method="post" action="[% uri_for('/admin/pingsweep') | none %]">
             <div class="form-horizontal">
-              <input placeholder="IP prefix e.g. 192.0.2.0/24" class="span4" name="device" required="required" type="text"/>
+              <input placeholder="IP prefix e.g. 192.0.2.0/24" class="span4" name="device" required="required" value="[% params.sweep | html_entity %]" type="text"/>
               <button type="submit" class="btn btn-info">Ping Sweep Network for Devices</button>
             </div>
           </form>

--- a/share/views/index.tt
+++ b/share/views/index.tt
@@ -72,9 +72,15 @@
           [% IF user_has_role('admin') %]
           <form class="nd_login-form" method="post" action="[% uri_for('/admin/discover') | none %]">
             <div class="form-horizontal">
-              <input placeholder="Device hostname or IP" class="span4" name="device" value="[% params.device | html_entity %]" type="text"/>
+              <input placeholder="Device hostname or IP address" class="span4" name="device" required="required" value="[% params.device | html_entity %]" type="text"/>
               <input type="hidden" name="extra" value="with-nodes"/>
-              <button type="submit" class="btn btn-info">Discover</button>
+              <button type="submit" class="btn btn-info">Discover Device and Neighbors</button>
+            </div>
+          </form>
+          <form class="nd_login-form" method="post" action="[% uri_for('/admin/pingsweep') | none %]">
+            <div class="form-horizontal">
+              <input placeholder="IP prefix e.g. 192.0.2.0/24" class="span4" name="device" required="required" type="text"/>
+              <button type="submit" class="btn btn-info">Ping Sweep Network for Devices</button>
             </div>
           </form>
           [% END %]


### PR DESCRIPTION
This worker is a utility which runs ping against an IP prefix and enqueues a discover job for any host that responds.

You'll need to install Net::Ping::External and have the ping utility installed on your system.

IP prefix is passed in the -p (port) parameter.
Timeout is 0.1 seconds default or pass any number to the -e (extra) parameter.

The IPs are pinged sequentially so it's as slow as num hosts x timeout. To parallelise and make things faster, queue the pingsweep job and use netdisco workers.

You could also run this as additional schedule config periodically for one or more IP prefixes.

The timeout is achieved using a signal because the timeout param to CLI ping is either integer (too slow) or root privilege or simply missing on some *nix platforms.