### PR TITLE
Implement of a MAC collector through SSH

### DIFF
--- a/lib/App/Netdisco/Transport/SSH.pm
+++ b/lib/App/Netdisco/Transport/SSH.pm
@@ -52,6 +52,11 @@ Returns C<undef> if the connection fails.
     my $self = shift;
     $self->platform->arpnip(@_, $self->host, $self->ssh, $self->auth);
   }
+
+  sub macsuck {
+    my $self = shift;
+    $self->plateform->macsuck(@_, $self->host, $self->ssh, $self->auth);
+  }
 }
 
 sub session_for {


### PR DESCRIPTION
Some Cisco devices doesn't support the `macsuck` function because they doesn't support the BridgeMIB to the retrieve MAC addresses connected to switch ports...

(By example, the Cisco C1100 series routers have a switch inside but doesn't support the BridgeMIB...)

So, I have created a simple macsuck function through the SSH collector to retrieve these data.
Like the SNMP collector, the function:
- retrieve the information concerning the current statu of interface
- retrieve the MAC table

Currently, I have done only the IOS platform but it could be interesting for other devices...