### PR TITLE
remove three limitations on python worklets

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -55,6 +55,7 @@ App::Netdisco::Builder->new(
     'File::Spec::Functions' => '0',
     'File::ShareDir' => '1.03',
     'File::Slurper' => '0.009',
+    'File::Temp' => '0.2311',
     'Guard' => '1.022',
     'HTML::Parser' => '3.70',
     'HTTP::Tiny' => '0.029',

--- a/Build.PL
+++ b/Build.PL
@@ -58,6 +58,7 @@ App::Netdisco::Builder->new(
     'Guard' => '1.022',
     'HTML::Parser' => '3.70',
     'HTTP::Tiny' => '0.029',
+    'IPC::Run' => '20231003.0',
     'IO::Socket::INET6' => '2.72',
     'IO::Socket::SSL' => '2.048',
     'JSON' => '2.90',

--- a/lib/App/Netdisco/Configuration.pm
+++ b/lib/App/Netdisco/Configuration.pm
@@ -78,6 +78,7 @@ if (ref {} eq ref setting('database')) {
     }
 
     # activate environment variables so that "psql" can be called
+    # and also used by python worklets to connect (to avoid reparsing config)
     $ENV{PGHOST} = $host if $host;
     $ENV{PGPORT} = $portnum if defined $portnum;
     $ENV{PGDATABASE} = $name;

--- a/lib/App/Netdisco/Transport/Python.pm
+++ b/lib/App/Netdisco/Transport/Python.pm
@@ -1,0 +1,114 @@
+package App::Netdisco::Transport::Python;
+
+use Dancer qw/:syntax :script/;
+
+use base 'Dancer::Object::Singleton';
+use aliased 'App::Netdisco::Worker::Status';
+use App::Netdisco::Util::Python 'py_cmd';
+
+use IPC::Run 'harness';
+use MIME::Base64 'decode_base64';
+use Path::Class;
+use File::ShareDir 'dist_dir';
+use JSON::PP ();
+use YAML::XS ();
+use Try::Tiny;
+
+=head1 NAME
+
+App::Netdisco::Transport::Python
+
+=head1 DESCRIPTION
+
+Not really a transport, but has similar behaviour to a Transport.
+
+Returns an object which has a live Python subprocess expecting
+instruction to run worklets.
+
+ my $runsub = App::Netdisco::Transport::Python->py_worklet();
+
+=cut
+
+__PACKAGE__->attributes(qw/ runner stdin stdout /);
+
+sub init {
+  my ( $class, $instance ) = @_;
+
+  my $cmd = [ py_cmd('run_worklet') ];
+  my ($stdin, $stdout);
+
+  my $harness = harness(
+    ($ENV{ND2_PYTHON_HARNESS_DEBUG} ? (debug => 1) : ()),
+    $cmd,
+    '<',  \$stdin,
+    '1>', \$stdout,
+    '2>', sub { debug $_[0] },
+  );
+
+  $instance->runner( $harness );
+  $instance->stdin( \$stdin );
+  $instance->stdout( \$stdout );
+
+  return $instance;
+}
+
+=head1 py_worklet( )
+
+Returns an object instance with a live Python subprocess.
+
+Will die if Python cannot be run.
+
+=cut
+
+sub py_worklet {
+  my ($self, $job, $workerconf) = @_;
+  my $action = $workerconf->{action};
+
+  my $coder = JSON::PP->new->utf8(1)
+                           ->allow_nonref(1)
+                           ->allow_unknown(1)
+                           ->allow_blessed(1)
+                           ->allow_bignum(1);
+
+  # this is only really used the first time (pump calls start)
+  $ENV{'ND2_JOB_METADATA'}  = $coder->encode( { %$job, device => (($job->device || '') .'') } );
+  $ENV{'ND2_CONFIGURATION'} = $coder->encode( config() );
+  $ENV{'ND2_FSM_TEMPLATES'} = Path::Class::Dir->new( dist_dir('App-Netdisco') )
+                                ->subdir('python')->subdir('tfsm')->stringify;
+
+  my $inref  = $self->stdin;
+  my $outref = $self->stdout;
+  
+  debug
+    sprintf "\N{RIGHTWARDS ARROW WITH HOOK} \N{SNAKE} dispatching to \%s",
+      $workerconf->{pyworklet};
+
+  $$inref = $workerconf->{pyworklet} ."\n";
+  $self->runner->pump until ($$outref and $$outref =~ /^\.\Z/m);
+
+  debug
+    sprintf "\N{LEFTWARDS ARROW WITH HOOK} \N{SNAKE} returned from \%s",
+      $workerconf->{pyworklet};
+
+  chomp(my $stdout = $$outref);
+  $stdout =~ s/\n\.//s;
+  $$outref = ''; # this is important for the next worklet to run
+
+  my $retdata = try { YAML::XS::Load(decode_base64($stdout)) }; # might explode
+  $retdata = {} if not ref $retdata or 'HASH' ne ref $retdata;
+
+  # use DDP;
+  # p $retdata;
+
+  my $status = $retdata->{status} || '';
+  my $log = $retdata->{log}
+    || ($status eq 'done' ? (sprintf '%s exit OK', $action)
+                          : (sprintf '%s exit with status "%s"', $action, $status));
+
+  # TODO support merging more deeply
+  var($_ => $retdata->{vars}->{$_}) for keys %{ $retdata->{vars} || {} };
+
+  return Status->$status($log);
+}
+
+true;

--- a/lib/App/Netdisco/Transport/Python.pm
+++ b/lib/App/Netdisco/Transport/Python.pm
@@ -42,6 +42,7 @@ sub init {
   $instance->stash( File::Temp->new() );
 
   my $cmd = [ py_cmd('run_worklet'), $instance->stash->filename ];
+  debug "\N{SNAKE} starting persistent Python worklet subprocess";
 
   $instance->runner( harness(
     ($ENV{ND2_PYTHON_HARNESS_DEBUG} ? (debug => 1) : ()),
@@ -82,17 +83,9 @@ sub py_worklet {
   my $inref  = $self->stdin;
   my $outref = $self->stdout;
   
-  debug
-    sprintf "\N{RIGHTWARDS ARROW WITH HOOK} \N{SNAKE} dispatching to \%s",
-      $workerconf->{pyworklet};
-
   $$outref = ''; # necessary before running, but do first to aid debugging
   $$inref = $workerconf->{pyworklet} ."\n";
   $self->runner->pump until ($$outref and $$outref =~ /^\.\Z/m);
-
-  debug
-    sprintf "\N{LEFTWARDS ARROW WITH HOOK} \N{SNAKE} returned from \%s",
-      $workerconf->{pyworklet};
 
   my $stash = read_text($self->stash->filename);
   truncate($self->stash, 0); # do not leave things lying around on disk

--- a/lib/App/Netdisco/Worker/Plugin/LoadMIBs.pm
+++ b/lib/App/Netdisco/Worker/Plugin/LoadMIBs.pm
@@ -8,7 +8,6 @@ use Dancer::Plugin::DBIC 'schema';
 
 use File::Spec::Functions qw(splitdir catfile catdir);
 use File::Slurper qw(read_lines write_text);
-use File::Temp;
 # use DDP;
 
 register_worker({ phase => 'main' }, sub {

--- a/lib/App/Netdisco/Worker/Plugin/PythonShim.pm
+++ b/lib/App/Netdisco/Worker/Plugin/PythonShim.pm
@@ -3,7 +3,7 @@ package App::Netdisco::Worker::Plugin::PythonShim;
 use Dancer ':syntax';
 use App::Netdisco::Worker::Plugin;
 
-use App::Netdisco::Util::Python qw/py_worklet/;
+use App::Netdisco::Transport::Python ();
 
 sub import {
   my ($pkg, $action) = @_;
@@ -83,7 +83,7 @@ sub _register_python_worklet {
       (exists $workerconf->{driver}    ? ($workerconf->{driver}    || '?') : '-'),
       (exists $workerconf->{priority}  ? ($workerconf->{priority}  || '?') : '-');
 
-  register_worker($workerconf, sub { py_worklet(@_) });
+  register_worker($workerconf, sub { App::Netdisco::Transport::Python->py_worklet(@_) });
 }
 
 sub _build_pyworklet {

--- a/lib/App/Netdisco/Worker/Runner.pm
+++ b/lib/App/Netdisco/Worker/Runner.pm
@@ -38,6 +38,7 @@ sub run {
   my $statusguard = guard {
     try { App::Netdisco::Transport::Python->runner->finish };
     try { App::Netdisco::Transport::Python->runner->kill_kill };
+    try { unlink App::Netdisco::Transport::Python->stash->filename };
     $job->finalise_status;
 };
 

--- a/share/python/netdisco/netdisco/runner.py
+++ b/share/python/netdisco/netdisco/runner.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from runpy import run_module
-from netdisco.util.worklet import context as c
+from netdisco.util.stash import stash
 from netdisco.util.perl import marshal_for_perl
 
 if len(sys.argv) < 2 or len(sys.argv[1]) == 0:
@@ -21,7 +21,7 @@ while True:
         action = worklet.split('.')[2]
         os.environ['ND2_JOB_METADATA'] = f'{{"action":"{action}"}}'
 
-    c.stash.load_stash()
+    stash.load_vars()
     gd = run_module(worklet, run_name='__main__')
 
     context = gd['c'] if 'c' in gd else gd['context'] if 'context' in gd else None

--- a/share/python/netdisco/netdisco/runner.py
+++ b/share/python/netdisco/netdisco/runner.py
@@ -3,6 +3,9 @@ import sys
 from runpy import run_module
 from netdisco.util.perl import marshal_for_perl
 
+if len(sys.argv) < 2 or len(sys.argv[1]) == 0:
+    raise Exception('Missing temporary filename or "-" for stash transfer')
+stashfile = sys.argv[1]
 
 while True:
     try:
@@ -21,5 +24,12 @@ while True:
 
     context = gd['c'] if 'c' in gd else gd['context'] if 'context' in gd else None
     retval = marshal_for_perl(context)
-    print(retval)
+
+    if stashfile == '-':
+        print(retval)
+    else:
+        stash = open(stashfile, 'w')
+        stash.write(retval)
+        stash.close()
+
     print('.')

--- a/share/python/netdisco/netdisco/runner.py
+++ b/share/python/netdisco/netdisco/runner.py
@@ -4,26 +4,22 @@ from runpy import run_module
 from netdisco.util.perl import marshal_for_perl
 
 
-def main():
-    if len(sys.argv) > 1:
-        action = sys.argv[1]
-    else:
-        raise Exception('missing action name to runner')
+while True:
+    try:
+        worklet = input()
+    except EOFError:
+        sys.exit(0)
+
+    if len(worklet) == 0:
+        sys.exit(0)
 
     if 'ND2_JOB_METADATA' not in os.environ:
+        action = worklet.split('.')[2]
         os.environ['ND2_JOB_METADATA'] = f'{{"action":"{action}"}}'
 
-    worklets = []
-    if len(sys.argv) > 2:
-        worklets = sys.argv[2:]
-    else:
-        raise Exception('missing worklet names to runner')
+    gd = run_module(worklet, run_name='__main__')
 
-    gd = run_module(worklets[0], run_name='__main__')
     context = gd['c'] if 'c' in gd else gd['context'] if 'context' in gd else None
     retval = marshal_for_perl(context)
     print(retval)
-
-
-if __name__ == '__main__':
-    main()
+    print('.')

--- a/share/python/netdisco/netdisco/runner.py
+++ b/share/python/netdisco/netdisco/runner.py
@@ -1,11 +1,12 @@
 import os
 import sys
 from runpy import run_module
+from netdisco.util.worklet import context as c
 from netdisco.util.perl import marshal_for_perl
 
 if len(sys.argv) < 2 or len(sys.argv[1]) == 0:
-    raise Exception('Missing temporary filename or "-" for stash transfer')
-stashfile = sys.argv[1]
+    raise Exception('Missing temporary filename or "-" for context transfer')
+contextfile = sys.argv[1]
 
 while True:
     try:
@@ -20,16 +21,16 @@ while True:
         action = worklet.split('.')[2]
         os.environ['ND2_JOB_METADATA'] = f'{{"action":"{action}"}}'
 
+    c.stash.load_stash()
     gd = run_module(worklet, run_name='__main__')
 
     context = gd['c'] if 'c' in gd else gd['context'] if 'context' in gd else None
     retval = marshal_for_perl(context)
 
-    if stashfile == '-':
+    if contextfile == '-':
         print(retval)
     else:
-        stash = open(stashfile, 'w')
-        stash.write(retval)
-        stash.close()
+        with open(contextfile, 'w') as cf:
+            cf.write(retval)
 
     print('.')

--- a/share/python/netdisco/netdisco/util/database.py
+++ b/share/python/netdisco/netdisco/util/database.py
@@ -1,0 +1,22 @@
+"""
+netdisco.util.database
+~~~~~~~~~~~~~~~~~~~~~~
+
+Access to Netdisco database using SQLAlchemy and psycopg (v3).
+"""
+
+import os
+from sqlalchemy import create_engine, URL
+
+db_connect_url = URL.create(
+    drivername='postgresql+psycopg',
+    username=os.environ.get('PGUSER', None),
+    password=os.environ.get('PGPASSWORD', None),
+    host=os.environ.get('PGHOST', None),
+    port=os.environ.get('PORT', None),
+    database=os.environ.get('PGDATABASE', None),
+)
+
+engine = create_engine(
+    db_connect_url, echo=False if os.environ.get('DBIC_TRACE', '0') == '0' else True
+)

--- a/share/python/netdisco/netdisco/util/perl.py
+++ b/share/python/netdisco/netdisco/util/perl.py
@@ -15,7 +15,7 @@ def marshal_for_perl(c):
     retval = {}
 
     if c is not None:
-        retval = {'status': c.status.status, 'log': c.status.log, 'vars': c.stash.store}
+        retval = {'status': c.status.status, 'log': c.status.log, 'stash': c.stash.store}
 
     jstr = json.dumps(retval, default=str)
     # debug('returning: ' + jstr)

--- a/share/python/netdisco/netdisco/util/stash.py
+++ b/share/python/netdisco/netdisco/util/stash.py
@@ -5,27 +5,40 @@ netdisco.util.stash
 Access to Netdisco vars() stash.
 """
 
-import os
 import json
+import sys
 from dataclasses import dataclass, field
 
-ND2_VARS = json.loads(os.environ.get('ND2_VARS', '{}'))
+
+def refresh_stash():
+    # this is safe because runner will have died if sys.arg[1] missing
+    contextfile = sys.argv[1]
+    with open(contextfile) as cf:
+        stash = json.loads(cf.read())['vars']
+    with open(contextfile, 'w') as cf:
+        cf.truncate(0)
+    return stash
 
 
 @dataclass(frozen=True)
 class StashManager:
     store: dict = field(default_factory=dict)
+    stash: dict = field(default_factory=dict)
 
     def get(self, key):
         if key in self.store:
             return self.store[key]
-        elif key in ND2_VARS:
-            return ND2_VARS[key]
+        elif key in self.stash:
+            return self.stash[key]
         else:
             raise KeyError(f'cannot find key "{key}" in Python stash or Perl/Dancer vars')
 
     def set(self, key, val):
         self.store[key] = val
+
+    def load_stash(self):
+        object.__setattr__(self, 'store', dict())
+        object.__setattr__(self, 'stash', refresh_stash())
 
 
 stash = StashManager()

--- a/share/python/netdisco/netdisco/util/stash.py
+++ b/share/python/netdisco/netdisco/util/stash.py
@@ -10,35 +10,42 @@ import sys
 from dataclasses import dataclass, field
 
 
-def refresh_stash():
+def refresh_vars():
     # this is safe because runner will have died if sys.arg[1] missing
     contextfile = sys.argv[1]
-    with open(contextfile) as cf:
-        stash = json.loads(cf.read())['vars']
-    with open(contextfile, 'w') as cf:
-        cf.truncate(0)
-    return stash
+    if contextfile == '-':
+        return dict()
+    
+    # this is pretty sloppy but works for now
+    try:
+        with open(contextfile, 'r') as cf:
+            vars = json.loads(cf.read())['vars']
+        with open(contextfile, 'w') as cf:
+            cf.truncate(0)
+        return vars
+    except Exception as e:
+        return dict()
 
 
 @dataclass(frozen=True)
 class StashManager:
+    vars: dict = field(default_factory=dict)
     store: dict = field(default_factory=dict)
-    stash: dict = field(default_factory=dict)
 
     def get(self, key):
         if key in self.store:
             return self.store[key]
-        elif key in self.stash:
-            return self.stash[key]
+        elif key in self.vars:
+            return self.vars[key]
         else:
             raise KeyError(f'cannot find key "{key}" in Python stash or Perl/Dancer vars')
 
     def set(self, key, val):
         self.store[key] = val
 
-    def load_stash(self):
+    def load_vars(self):
+        object.__setattr__(self, 'vars', refresh_vars())
         object.__setattr__(self, 'store', dict())
-        object.__setattr__(self, 'stash', refresh_stash())
 
 
 stash = StashManager()

--- a/share/python/netdisco/netdisco/worklet/stats/early.py
+++ b/share/python/netdisco/netdisco/worklet/stats/early.py
@@ -1,9 +1,11 @@
 import platform
+from netdisco.util.log import debug
 from netdisco.util.worklet import context as c
 
 
 def main():
     c.stash.set('python_ver', platform.python_version())
+    debug('python version is: ' + c.stash.get('python_ver'))
     c.status.info('stashed Python version')
 
 

--- a/share/python/netdisco/netdisco/worklet/stats/early.py
+++ b/share/python/netdisco/netdisco/worklet/stats/early.py
@@ -1,6 +1,5 @@
 import platform
-from netdisco.util.log import debug
-from netdisco.util.worklet import context as c
+from netdisco.util.worklet import debug, context as c
 
 
 def main():

--- a/share/python/netdisco/pyproject.toml
+++ b/share/python/netdisco/pyproject.toml
@@ -18,6 +18,8 @@ yamale = "^5.2.1"
 netmiko = "^4.4.0"
 cryptography = "^43.0.1"
 virtualenv = ">=20.26.6"
+sqlalchemy = "^2.0.37"
+psycopg = "^3.2.4"
 
 [tool.poetry.scripts]
 run_worklet = "netdisco.runner:main"


### PR DESCRIPTION
this change removes three limitations:

- there is now basic database connectivity available (`from netdisco.util.database import engine`)
- one python subprocess is started (lazily) for all worklets in a job
- vars is now transferred in a temporary file so unrestricted in size (config is still transferred in environment for security)