### PR TITLE
Add branding text option to web UI

### DIFF
--- a/share/config.yml
+++ b/share/config.yml
@@ -25,6 +25,7 @@ tenant_databases: []
 # ------------
 
 domain_suffix: []
+branding_text: Netdisco
 no_auth: false
 suggest_guest: false
 navbar_autocomplete: true

--- a/share/environments/deployment.yml
+++ b/share/environments/deployment.yml
@@ -42,10 +42,6 @@ device_auth:
 # ````````````````````````````````````````````````````````````
 #session_secure: true
 
-# change the branding in the web UI "brand" html class. Default is "Netdisco"
-# ```````````````````````````````````````````````````````
-#branding_text: Netdisco
-
 # ¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸
 #
 # SOME MORE INTERESTING SETTINGS WHERE THE DEFAULTS ARE PROBABLY OKAY

--- a/share/environments/deployment.yml
+++ b/share/environments/deployment.yml
@@ -42,6 +42,10 @@ device_auth:
 # ````````````````````````````````````````````````````````````
 #session_secure: true
 
+# change the branding in the web UI "brand" html class. Default is "Netdisco"
+# ```````````````````````````````````````````````````````
+#branding_text: Netdisco
+
 # ¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸.·´¯`·.¸¸
 #
 # SOME MORE INTERESTING SETTINGS WHERE THE DEFAULTS ARE PROBABLY OKAY

--- a/share/views/layouts/main.tt
+++ b/share/views/layouts/main.tt
@@ -76,7 +76,7 @@
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="brand" href="[% uri_for('/') %]">[% IF !settings.branding_text; "Netdisco"; ELSE; settings.branding_text; END %]</a>
+      <a class="brand" href="[% uri_for('') %]">[% IF !settings.branding_text; "Netdisco"; ELSE; settings.branding_text; END %]</a>
       [% IF session.logged_in_user %]
       <ul class="nav">
         [% FOREACH ni IN settings._navbar_items %]

--- a/share/views/layouts/main.tt
+++ b/share/views/layouts/main.tt
@@ -76,7 +76,7 @@
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="brand" href="[% uri_for('') %]">[% IF !settings.branding_text; "Netdisco"; ELSE; settings.branding_text; END %]</a>
+      <a class="brand" href="[% uri_for('') %]">[% settings.branding_text %]</a>
       [% IF session.logged_in_user %]
       <ul class="nav">
         [% FOREACH ni IN settings._navbar_items %]

--- a/share/views/layouts/main.tt
+++ b/share/views/layouts/main.tt
@@ -76,7 +76,7 @@
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="brand" href="[% uri_for('') %]">[% settings.branding_text %]</a>
+      <a class="brand" href="[% uri_for('') | none %]">[% settings.branding_text %]</a>
       [% IF session.logged_in_user %]
       <ul class="nav">
         [% FOREACH ni IN settings._navbar_items %]

--- a/share/views/layouts/main.tt
+++ b/share/views/layouts/main.tt
@@ -76,7 +76,7 @@
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="brand" href="[% uri_for('') | none %]">Netdisco</a>
+      <a class="brand" href="[% uri_for('/') %]">[% IF !settings.branding_text; "Netdisco"; ELSE; settings.branding_text; END %]</a>
       [% IF session.logged_in_user %]
       <ul class="nav">
         [% FOREACH ni IN settings._navbar_items %]


### PR DESCRIPTION
Include an optional branding configuration option.
Adding a branding_text option to the deployment.yaml will allow customization of the header.
eg: `branding_text: Netdisco XYZ Corporate Office`
if this option is not set, it will default to "Netdisco"