### PR TITLE
function to retrieve subnets from NXOS devices via cli

### DIFF
--- a/lib/App/Netdisco/Transport/SSH.pm
+++ b/lib/App/Netdisco/Transport/SSH.pm
@@ -59,6 +59,12 @@ Returns C<undef> if the connection fails.
     $self->platform->macsuck(@_, $self->host, $self->ssh, $self->auth)
       if $self->platform->can('macsuck');
   }
+
+  sub subnets {
+    my $self = shift;
+    $self->platform->subnets(@_, $self->host, $self->ssh, $self->auth)
+        if $self->platform->can('subnets');
+  }
 }
 
 sub session_for {


### PR DESCRIPTION
This adds a function to the NXOS SSHCollector module which retrieves subnets
by getting the routing table for all vrfs via cli and then filters for attached nets and ignoring /32.

closes #1323 