### PR TITLE
Add REST API endpoint for statistics

### DIFF
--- a/lib/App/Netdisco/Web.pm
+++ b/lib/App/Netdisco/Web.pm
@@ -130,6 +130,7 @@ use App::Netdisco::Web::Device;
 use App::Netdisco::Web::Report;
 use App::Netdisco::Web::API::Objects;
 use App::Netdisco::Web::API::Queue;
+use App::Netdisco::Web::API::Statistics;
 use App::Netdisco::Web::AdminTask;
 use App::Netdisco::Web::TypeAhead;
 use App::Netdisco::Web::PortControl;

--- a/lib/App/Netdisco/Web/API/Statistics.pm
+++ b/lib/App/Netdisco/Web/API/Statistics.pm
@@ -1,0 +1,23 @@
+package App::Netdisco::Web::API::Statistics;
+
+use Dancer ':syntax';
+use Dancer::Plugin::DBIC;
+use Dancer::Plugin::Swagger;
+use Dancer::Plugin::Auth::Extensible;
+
+use Try::Tiny;
+
+swagger_path {
+  tags => ['Statistics'],
+  path => (setting('api_base') || '').'/object/statistics',
+  description => 'Returns the latest row from the statistics table',
+  responses => { default => {} },
+}, get '/api/v1/object/statistics' => require_role api => sub {
+  my $stats = try {
+    schema(vars->{'tenant'})->resultset('Statistics')
+      ->search(undef, { order_by => { -desc => 'day' }, rows => 1 })->first
+  } or send_error('No statistics available', 404);
+  return to_json $stats->TO_JSON;
+};
+
+true;


### PR DESCRIPTION
Expose GET /api/v1/object/statistics returning the latest row from the statistics table as JSON. Requires the api role, documented via Swagger.

from the lab:
```
curl -k -X GET "https://foo.example.com/api/v1/object/statistics" ...| jq
{
  "device_link_count": 378,
  "netdisco_ver": "2.97.3",
  "ip_active_count": 11962,
  "device_ip_count": 1404,
  "day": "2026-04-11",
  "pg_ver": "18.00.2",
  "ip_table_count": 13162,
  "device_port_up_count": 10367,
  "python_ver": "3.12.12",
  "phone_count": 25,
  "wap_count": 764,
  "perl_ver": "5.40.3",
  "snmpinfo_ver": "3.975.0",
  "node_table_count": 23168,
  "device_count": 235,
  "device_port_count": 24387,
  "schema_ver": "96",
  "node_active_count": 10746
}
```

decided to not to use `/report/..` space as its reserved for the plugin-driven report system. `/object/statistics` keeps consistency with other direct table reads; 