### PR TITLE
Fix/hook and jobqueue improvements

### DIFF
--- a/lib/App/Netdisco/Util/Worker.pm
+++ b/lib/App/Netdisco/Util/Worker.pm
@@ -14,6 +14,17 @@ our @EXPORT = ('queue_hook');
 
 sub queue_hook {
   my ($hook, $conf) = @_;
+
+  unless ($conf->{'type'}) {
+    warning sprintf ' hooks - missing type in hook config for event "%s", skipping', ($hook || '?');
+    return 0;
+  }
+
+  unless (lc($conf->{'type'}) =~ m/^(?:http|exec)$/) {
+    warning sprintf ' hooks - unknown hook type "%s" for event "%s", skipping', $conf->{'type'}, ($hook || '?');
+    return 0;
+  }
+
   my $hook_data = dclone (vars->{'hook_data'} || {});
   my $extra = { action_conf => dclone ($conf->{'with'} || {}),
                 event_data  => dclone ($hook_data) };

--- a/share/views/ajax/admintask/jobqueue.tt
+++ b/share/views/ajax/admintask/jobqueue.tt
@@ -16,7 +16,7 @@
     <tr>
       <th class="nd_center-cell">Backend</th>
       <th class="nd_center-cell">Action</th>
-      <th class="nd_center-cell">Device</th>
+      <th class="nd_center-cell">Device / Info</th>
       <th class="nd_center-cell">Submitted By</th>
       <th class="nd_center-cell">Status</th>
       <th class="nd_center-cell">Duration</th>
@@ -41,10 +41,14 @@
       </td>
 
       <td class="nd_center-cell">
-        [% IF row.action == 'discover' AND row.status == 'error' %]
-        <a href="[% uri_for('/') | none %]?device=[% row.device | uri %]">[% row.device | html_entity %]</a>
+        [% IF row.device %]
+          [% IF row.action == 'discover' AND row.status == 'error' %]
+          <a href="[% uri_for('/') | none %]?device=[% row.device | uri %]">[% row.device | html_entity %]</a>
+          [% ELSE %]
+          <a href="[% uri_for('/device') | none %]?q=[% row.device | uri %]">[% row.target.dns || row.device | html_entity %]</a>
+          [% END %]
         [% ELSE %]
-        <a href="[% uri_for('/device') | none %]?q=[% row.device | uri %]">[% row.target.dns || row.device | html_entity %]</a>
+        <span title="[% row.log | html_entity %]">[% row.log.substr(0, 40) | html_entity %][% '...' IF row.log.length > 40 %]</span>
         [% END %]
       </td>
 


### PR DESCRIPTION
stumbled on that while I had a wrong config syntax: 

  - Validate type field in hook config before queuing: missing or unknown types now log a clear warning and skip the hook instead of producing a Perl uninitialised value warning and a cryptic _"failed to report from any worker"_ error in the UI

and think this is a small ui improovment:
  -  Job queue table: Tune "Device" column to "Device / Info" and show the first chars of the log (with full text on hover) for jobs without a device, giving visibility into hook and other non-device job results without needing to expand the details row:
<img width="483" height="311" alt="image" src="https://github.com/user-attachments/assets/005abccb-b0e9-4f95-af03-3870ca1fcbe7" />
