### PR TITLE
Add /health and /metrics endpoints

### DIFF
--- a/lib/App/Netdisco/Web.pm
+++ b/lib/App/Netdisco/Web.pm
@@ -131,6 +131,8 @@ use App::Netdisco::Web::Report;
 use App::Netdisco::Web::API::Objects;
 use App::Netdisco::Web::API::Queue;
 use App::Netdisco::Web::API::Statistics;
+use App::Netdisco::Web::Health;
+use App::Netdisco::Web::Metrics;
 use App::Netdisco::Web::AdminTask;
 use App::Netdisco::Web::TypeAhead;
 use App::Netdisco::Web::PortControl;

--- a/lib/App/Netdisco/Web/AuthN.pm
+++ b/lib/App/Netdisco/Web/AuthN.pm
@@ -59,6 +59,8 @@ hook 'before' => sub {
       or request->path eq uri_for('/logout')->path
       or request->path eq uri_for('/swagger.json')->path
       or index(request->path, uri_for('/swagger-ui')->path) == 0
+      or request->path eq uri_for('/health')->path
+      or request->path eq uri_for('/metrics')->path
     );
 
     # Dancer will issue a cookie to the client which could be returned and

--- a/lib/App/Netdisco/Web/AuthN.pm
+++ b/lib/App/Netdisco/Web/AuthN.pm
@@ -59,8 +59,8 @@ hook 'before' => sub {
       or request->path eq uri_for('/logout')->path
       or request->path eq uri_for('/swagger.json')->path
       or index(request->path, uri_for('/swagger-ui')->path) == 0
-      or request->path eq uri_for('/health')->path
-      or request->path eq uri_for('/metrics')->path
+      or (setting('health_path')  and request->path eq uri_for(setting('health_path'))->path)
+      or (setting('metrics_path') and request->path eq uri_for(setting('metrics_path'))->path)
     );
 
     # Dancer will issue a cookie to the client which could be returned and

--- a/lib/App/Netdisco/Web/Health.pm
+++ b/lib/App/Netdisco/Web/Health.pm
@@ -1,0 +1,36 @@
+package App::Netdisco::Web::Health;
+
+use Dancer ':syntax';
+use Dancer::Plugin::DBIC;
+
+use Try::Tiny;
+
+get '/health' => sub {
+  content_type 'application/json';
+
+  my $db_ok = try {
+    schema('netdisco')->storage->dbh->ping;
+    1;
+  } catch { 0 };
+
+  my @backends = try {
+    schema('netdisco')->resultset('DeviceSkip')
+      ->search({ device => '255.255.255.255' })->hri->all;
+  } catch { () };
+
+  my $num_backends = scalar @backends;
+  my $tot_workers  = 0;
+  $tot_workers += $_->{deferrals} for @backends;
+
+  my $status = $db_ok ? 'ok' : 'degraded';
+  status( $db_ok ? 200 : 503 );
+
+  return to_json {
+    status   => $status,
+    db       => ($db_ok ? 'ok' : 'error'),
+    backends => $num_backends,
+    workers  => $tot_workers,
+  };
+};
+
+true;

--- a/lib/App/Netdisco/Web/Health.pm
+++ b/lib/App/Netdisco/Web/Health.pm
@@ -5,32 +5,34 @@ use Dancer::Plugin::DBIC;
 
 use Try::Tiny;
 
-get '/health' => sub {
-  content_type 'application/json';
+if (my $path = setting('health_path')) {
+  get $path => sub {
+    content_type 'application/json';
 
-  my $db_ok = try {
-    schema('netdisco')->storage->dbh->ping;
-    1;
-  } catch { 0 };
+    my $db_ok = try {
+      schema('netdisco')->storage->dbh->ping;
+      1;
+    } catch { 0 };
 
-  my @backends = try {
-    schema('netdisco')->resultset('DeviceSkip')
-      ->search({ device => '255.255.255.255' })->hri->all;
-  } catch { () };
+    my @backends = try {
+      schema('netdisco')->resultset('DeviceSkip')
+        ->search({ device => '255.255.255.255' })->hri->all;
+    } catch { () };
 
-  my $num_backends = scalar @backends;
-  my $tot_workers  = 0;
-  $tot_workers += $_->{deferrals} for @backends;
+    my $num_backends = scalar @backends;
+    my $tot_workers  = 0;
+    $tot_workers += $_->{deferrals} for @backends;
 
-  my $status = $db_ok ? 'ok' : 'degraded';
-  status( $db_ok ? 200 : 503 );
+    my $status = $db_ok ? 'ok' : 'degraded';
+    status( $db_ok ? 200 : 503 );
 
-  return to_json {
-    status   => $status,
-    db       => ($db_ok ? 'ok' : 'error'),
-    backends => $num_backends,
-    workers  => $tot_workers,
+    return to_json {
+      status   => $status,
+      db       => ($db_ok ? 'ok' : 'error'),
+      backends => $num_backends,
+      workers  => $tot_workers,
+    };
   };
-};
+}
 
 true;

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -4,6 +4,7 @@ use Dancer ':syntax';
 use Dancer::Plugin::DBIC;
 
 use App::Netdisco::Util::Permission 'acl_matches';
+use POSIX 'floor';
 use Try::Tiny;
 
 sub _header {
@@ -53,17 +54,17 @@ get '/metrics' => sub {
 
   # -- Statistics metrics (one row per tenant) -------------------------------
   my @stat_metrics = (
-    [ netdisco_devices_total      => 'device_count',        'Total number of discovered devices' ],
-    [ netdisco_device_ips         => 'device_ip_count',     'Total number of device IP addresses' ],
-    [ netdisco_device_links       => 'device_link_count',   'Total number of layer2 links between devices' ],
-    [ netdisco_device_ports       => 'device_port_count',   'Total number of device ports' ],
-    [ netdisco_device_ports_up    => 'device_port_up_count','Total number of device ports with up/up status' ],
-    [ netdisco_ip_table           => 'ip_table_count',      'Total number of IP table entries' ],
-    [ netdisco_ip_active          => 'ip_active_count',     'Total number of active IP entries' ],
-    [ netdisco_nodes              => 'node_table_count',    'Total number of node entries' ],
-    [ netdisco_nodes_active       => 'node_active_count',   'Total number of active nodes' ],
-    [ netdisco_phones             => 'phone_count',         'Total number of discovered VoIP phones' ],
-    [ netdisco_waps               => 'wap_count',           'Total number of discovered wireless access points' ],
+    [ netdisco_devices        => 'device_count',        'Total number of discovered devices' ],
+    [ netdisco_device_ips     => 'device_ip_count',     'Total number of device IP addresses' ],
+    [ netdisco_device_links   => 'device_link_count',   'Total number of layer2 links between devices' ],
+    [ netdisco_device_ports   => 'device_port_count',   'Total number of device ports' ],
+    [ netdisco_device_ports_up => 'device_port_up_count','Total number of device ports with up/up status' ],
+    [ netdisco_ip_table       => 'ip_table_count',      'Total number of IP table entries' ],
+    [ netdisco_ip_active      => 'ip_active_count',     'Total number of active IP entries' ],
+    [ netdisco_nodes          => 'node_table_count',    'Total number of node entries' ],
+    [ netdisco_nodes_active   => 'node_active_count',   'Total number of active nodes' ],
+    [ netdisco_phones         => 'phone_count',         'Total number of discovered VoIP phones' ],
+    [ netdisco_waps           => 'wap_count',           'Total number of discovered wireless access points' ],
   );
 
   foreach my $m (@stat_metrics) {
@@ -80,6 +81,39 @@ get '/metrics' => sub {
     $output .= "\n";
   }
 
+  # Age of latest statistics row in seconds
+  $output .= _header('netdisco_stats_age_seconds', 'Age of the latest statistics snapshot in seconds');
+  foreach my $tenant (@tenants) {
+    my $age = try {
+      schema($tenant)->resultset('Statistics')->search(undef, {
+        select => [ \"extract(epoch FROM (now() - max(day)::timestamp))" ],
+        as     => ['age'],
+      })->first->get_column('age');
+    };
+    next unless defined $age;
+    $output .= _sample('netdisco_stats_age_seconds', floor($age), tenant => $tenant);
+  }
+  $output .= "\n";
+
+  # -- Backend / worker health -----------------------------------------------
+  $output .= _header('netdisco_backends', 'Number of active backend instances');
+  $output .= _header('netdisco_workers',  'Total number of worker slots across all backends');
+
+  my $backends_output = '';
+  my $workers_output  = '';
+  foreach my $tenant (@tenants) {
+    my @backends = try {
+      schema($tenant)->resultset('DeviceSkip')
+        ->search({ device => '255.255.255.255' })->hri->all;
+    } catch { () };
+    my $tot_workers = 0;
+    $tot_workers += $_->{deferrals} for @backends;
+    $backends_output .= _sample('netdisco_backends', scalar @backends, tenant => $tenant);
+    $workers_output  .= _sample('netdisco_workers',  $tot_workers,     tenant => $tenant);
+  }
+  $output .= $backends_output . "\n";
+  $output .= $workers_output  . "\n";
+
   # -- Job queue metrics (live, per tenant) ----------------------------------
 
   # Counts by status
@@ -93,7 +127,7 @@ get '/metrics' => sub {
   }
   $output .= "\n";
 
-  # Running jobs
+  # Running and stale jobs
   $output .= _header('netdisco_jobs_running', 'Number of jobs currently running');
   foreach my $tenant (@tenants) {
     my $rs = try { schema($tenant)->resultset('Admin') } or next;
@@ -101,6 +135,20 @@ get '/metrics' => sub {
       $rs->search({ status => 'queued', backend => { '!=' => undef } })->count;
     } catch { 0 };
     $output .= _sample('netdisco_jobs_running', $running, tenant => $tenant);
+  }
+  $output .= "\n";
+
+  $output .= _header('netdisco_jobs_stale', 'Number of stale jobs (running longer than jobs_stale_after)');
+  foreach my $tenant (@tenants) {
+    my $rs = try { schema($tenant)->resultset('Admin') } or next;
+    my $stale = try {
+      $rs->search({
+        status  => 'queued',
+        backend => { '!=' => undef },
+        started => \[ q/<= (LOCALTIMESTAMP - ?::interval)/, setting('jobs_stale_after') ],
+      })->count;
+    } catch { 0 };
+    $output .= _sample('netdisco_jobs_stale', $stale, tenant => $tenant);
   }
   $output .= "\n";
 
@@ -141,6 +189,42 @@ get '/metrics' => sub {
       next unless defined $row->{avg_duration};
       $output .= sprintf(qq(netdisco_job_duration_seconds{tenant="%s",action="%s"} %.3f\n),
         $tenant, $row->{action}, $row->{avg_duration});
+    }
+  }
+  $output .= "\n";
+
+  # -- Device inventory metrics ----------------------------------------------
+
+  $output .= _header('netdisco_devices_by_vendor', 'Number of devices grouped by vendor');
+  foreach my $tenant (@tenants) {
+    my @rows = try {
+      schema($tenant)->resultset('Device')->search(undef, {
+        select   => [ 'mftr', { count => '*', -as => 'cnt' } ],
+        as       => [qw/mftr cnt/],
+        group_by => ['mftr'],
+      })->hri->all;
+    } catch { () };
+    foreach my $row (@rows) {
+      my $vendor = $row->{mftr} // 'unknown';
+      $output .= _sample('netdisco_devices_by_vendor', $row->{cnt},
+        tenant => $tenant, vendor => $vendor);
+    }
+  }
+  $output .= "\n";
+
+  $output .= _header('netdisco_devices_by_os', 'Number of devices grouped by OS version');
+  foreach my $tenant (@tenants) {
+    my @rows = try {
+      schema($tenant)->resultset('Device')->search(undef, {
+        select   => [ 'os', { count => '*', -as => 'cnt' } ],
+        as       => [qw/os cnt/],
+        group_by => ['os'],
+      })->hri->all;
+    } catch { () };
+    foreach my $row (@rows) {
+      my $os = $row->{os} // 'unknown';
+      $output .= _sample('netdisco_devices_by_os', $row->{cnt},
+        tenant => $tenant, os => $os);
     }
   }
   $output .= "\n";

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -6,15 +6,18 @@ use Dancer::Plugin::DBIC;
 use App::Netdisco::Util::Permission 'acl_matches';
 use Try::Tiny;
 
-# Emit a gauge metric line with optional labels
-sub _gauge {
-  my ($name, $help, $value, %labels) = @_;
+sub _header {
+  my ($name, $help) = @_;
+  return sprintf("# HELP %s %s\n# TYPE %s gauge\n", $name, $help, $name);
+}
+
+sub _sample {
+  my ($name, $value, %labels) = @_;
   my $label_str = '';
   if (%labels) {
     $label_str = '{'. join(',', map { qq($_="$labels{$_}") } sort keys %labels) .'}';
   }
-  return sprintf("# HELP %s %s\n# TYPE %s gauge\n%s%s %s\n",
-    $name, $help, $name, $name, $label_str, $value // 0);
+  return sprintf("%s%s %s\n", $name, $label_str, $value // 0);
 }
 
 get '/metrics' => sub {
@@ -49,74 +52,62 @@ get '/metrics' => sub {
   my $output = '';
 
   # -- Statistics metrics (one row per tenant) -------------------------------
-  my %stat_metrics = (
-    netdisco_devices_total        => 'Total number of discovered devices',
-    netdisco_device_ips_total     => 'Total number of device IP addresses',
-    netdisco_device_links_total   => 'Total number of layer2 links between devices',
-    netdisco_device_ports_total   => 'Total number of device ports',
-    netdisco_device_ports_up      => 'Total number of device ports with up/up status',
-    netdisco_ip_table_total       => 'Total number of IP table entries',
-    netdisco_ip_active_total      => 'Total number of active IP entries',
-    netdisco_nodes_total          => 'Total number of node entries',
-    netdisco_nodes_active_total   => 'Total number of active nodes',
-    netdisco_phones_total         => 'Total number of discovered VoIP phones',
-    netdisco_waps_total           => 'Total number of discovered wireless access points',
+  my @stat_metrics = (
+    [ netdisco_devices_total      => 'device_count',        'Total number of discovered devices' ],
+    [ netdisco_device_ips         => 'device_ip_count',     'Total number of device IP addresses' ],
+    [ netdisco_device_links       => 'device_link_count',   'Total number of layer2 links between devices' ],
+    [ netdisco_device_ports       => 'device_port_count',   'Total number of device ports' ],
+    [ netdisco_device_ports_up    => 'device_port_up_count','Total number of device ports with up/up status' ],
+    [ netdisco_ip_table           => 'ip_table_count',      'Total number of IP table entries' ],
+    [ netdisco_ip_active          => 'ip_active_count',     'Total number of active IP entries' ],
+    [ netdisco_nodes              => 'node_table_count',    'Total number of node entries' ],
+    [ netdisco_nodes_active       => 'node_active_count',   'Total number of active nodes' ],
+    [ netdisco_phones             => 'phone_count',         'Total number of discovered VoIP phones' ],
+    [ netdisco_waps               => 'wap_count',           'Total number of discovered wireless access points' ],
   );
 
-  my %stat_columns = (
-    netdisco_devices_total        => 'device_count',
-    netdisco_device_ips_total     => 'device_ip_count',
-    netdisco_device_links_total   => 'device_link_count',
-    netdisco_device_ports_total   => 'device_port_count',
-    netdisco_device_ports_up      => 'device_port_up_count',
-    netdisco_ip_table_total       => 'ip_table_count',
-    netdisco_ip_active_total      => 'ip_active_count',
-    netdisco_nodes_total          => 'node_table_count',
-    netdisco_nodes_active_total   => 'node_active_count',
-    netdisco_phones_total         => 'phone_count',
-    netdisco_waps_total           => 'wap_count',
-  );
-
-  foreach my $metric (sort keys %stat_metrics) {
-    $output .= sprintf("# HELP %s %s\n# TYPE %s gauge\n",
-      $metric, $stat_metrics{$metric}, $metric);
-
+  foreach my $m (@stat_metrics) {
+    my ($metric, $col, $help) = @$m;
+    $output .= _header($metric, $help);
     foreach my $tenant (@tenants) {
       my $stats = try {
         schema($tenant)->resultset('Statistics')
           ->search(undef, { order_by => { -desc => 'day' }, rows => 1 })->first;
       };
       next unless $stats;
-      my $col = $stat_columns{$metric};
-      $output .= sprintf("%s{tenant=\"%s\"} %s\n",
-        $metric, $tenant, $stats->$col // 0);
+      $output .= _sample($metric, $stats->$col // 0, tenant => $tenant);
     }
     $output .= "\n";
   }
 
   # -- Job queue metrics (live, per tenant) ----------------------------------
+
+  # Counts by status
+  $output .= _header('netdisco_jobs', 'Number of jobs in the queue by status');
   foreach my $tenant (@tenants) {
     my $rs = try { schema($tenant)->resultset('Admin') } or next;
-
-    # Counts by status
     foreach my $st (qw/queued done error/) {
       my $count = try { $rs->search({ status => $st })->count } catch { 0 };
-      $output .= _gauge('netdisco_jobs_total',
-        'Number of jobs in the queue by status',
-        $count, tenant => $tenant, status => $st);
+      $output .= _sample('netdisco_jobs', $count, tenant => $tenant, status => $st);
     }
+  }
+  $output .= "\n";
 
-    # Running (queued + assigned to backend)
+  # Running jobs
+  $output .= _header('netdisco_jobs_running', 'Number of jobs currently running');
+  foreach my $tenant (@tenants) {
+    my $rs = try { schema($tenant)->resultset('Admin') } or next;
     my $running = try {
       $rs->search({ status => 'queued', backend => { '!=' => undef } })->count;
     } catch { 0 };
-    $output .= _gauge('netdisco_jobs_running',
-      'Number of jobs currently running',
-      $running, tenant => $tenant);
+    $output .= _sample('netdisco_jobs_running', $running, tenant => $tenant);
+  }
+  $output .= "\n";
 
-    # Counts by action+status
-    $output .= "# HELP netdisco_jobs_by_action Number of jobs grouped by action and status\n";
-    $output .= "# TYPE netdisco_jobs_by_action gauge\n";
+  # Counts by action+status
+  $output .= _header('netdisco_jobs_by_action', 'Number of jobs grouped by action and status');
+  foreach my $tenant (@tenants) {
+    my $rs = try { schema($tenant)->resultset('Admin') } or next;
     my @by_action = try {
       $rs->search(undef, {
         select   => ['action', 'status', { count => '*', -as => 'cnt' }],
@@ -124,16 +115,17 @@ get '/metrics' => sub {
         group_by => [qw/action status/],
       })->hri->all;
     } catch { () };
-
     foreach my $row (@by_action) {
-      $output .= sprintf(qq(netdisco_jobs_by_action{tenant="%s",action="%s",status="%s"} %s\n),
-        $tenant, $row->{action}, $row->{status}, $row->{cnt});
+      $output .= _sample('netdisco_jobs_by_action', $row->{cnt},
+        tenant => $tenant, action => $row->{action}, status => $row->{status});
     }
-    $output .= "\n";
+  }
+  $output .= "\n";
 
-    # Average duration of completed jobs by action (in seconds)
-    $output .= "# HELP netdisco_job_duration_seconds Average duration of completed jobs by action\n";
-    $output .= "# TYPE netdisco_job_duration_seconds gauge\n";
+  # Average duration of completed jobs by action
+  $output .= _header('netdisco_job_duration_seconds', 'Average duration of completed jobs by action in seconds');
+  foreach my $tenant (@tenants) {
+    my $rs = try { schema($tenant)->resultset('Admin') } or next;
     my @durations = try {
       $rs->search(
         { status => 'done', started => { '!=' => undef }, finished => { '!=' => undef } },
@@ -145,14 +137,13 @@ get '/metrics' => sub {
         }
       )->hri->all;
     } catch { () };
-
     foreach my $row (@durations) {
       next unless defined $row->{avg_duration};
       $output .= sprintf(qq(netdisco_job_duration_seconds{tenant="%s",action="%s"} %.3f\n),
         $tenant, $row->{action}, $row->{avg_duration});
     }
-    $output .= "\n";
   }
+  $output .= "\n";
 
   return $output;
 };

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -100,7 +100,7 @@ get '/metrics' => sub {
 
     # Counts by status
     foreach my $st (qw/queued done error/) {
-      my $count = try { $rs->search({ status => $st })->count } // 0;
+      my $count = try { $rs->search({ status => $st })->count } catch { 0 };
       $output .= _gauge('netdisco_jobs_total',
         'Number of jobs in the queue by status',
         $count, tenant => $tenant, status => $st);
@@ -109,7 +109,7 @@ get '/metrics' => sub {
     # Running (queued + assigned to backend)
     my $running = try {
       $rs->search({ status => 'queued', backend => { '!=' => undef } })->count;
-    } // 0;
+    } catch { 0 };
     $output .= _gauge('netdisco_jobs_running',
       'Number of jobs currently running',
       $running, tenant => $tenant);

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -21,7 +21,8 @@ sub _sample {
   return sprintf("%s%s %s\n", $name, $label_str, $value // 0);
 }
 
-get '/metrics' => sub {
+if (my $metrics_path = setting('metrics_path')) {
+get $metrics_path => sub {
   # Optional IP range restriction
   my $allow = setting('metrics_allow');
   if ($allow and ref $allow eq ref []) {
@@ -199,13 +200,13 @@ get '/metrics' => sub {
   foreach my $tenant (@tenants) {
     my @rows = try {
       schema($tenant)->resultset('Device')->search(undef, {
-        select   => [ 'mftr', { count => '*', -as => 'cnt' } ],
-        as       => [qw/mftr cnt/],
-        group_by => ['mftr'],
+        select   => [ 'vendor', { count => '*', -as => 'cnt' } ],
+        as       => [qw/vendor cnt/],
+        group_by => ['vendor'],
       })->hri->all;
     } catch { () };
     foreach my $row (@rows) {
-      my $vendor = $row->{mftr} // 'unknown';
+      my $vendor = $row->{vendor} // 'unknown';
       $output .= _sample('netdisco_devices_by_vendor', $row->{cnt},
         tenant => $tenant, vendor => $vendor);
     }
@@ -323,5 +324,6 @@ get '/metrics' => sub {
 
   return $output;
 };
+}
 
 true;

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -229,6 +229,61 @@ get '/metrics' => sub {
   }
   $output .= "\n";
 
+  # -- Slow devices (top 20 per tenant, bounded cardinality) -----------------
+  $output .= _header('netdisco_slow_device_duration_seconds',
+    'Duration of last completed job for the 20 slowest devices by action (discover/macsuck/arpnip)');
+  foreach my $tenant (@tenants) {
+    my @rows = try {
+      schema($tenant)->resultset('Virtual::SlowDevices')->search(undef)->hri->all;
+    } catch { () };
+    foreach my $row (@rows) {
+      next unless defined $row->{device} and defined $row->{elapsed};
+      # elapsed is a PG interval string like "00:00:45.2" - convert to seconds
+      my $secs = 0;
+      if ($row->{elapsed} =~ m/(\d+):(\d+):(\d+(?:\.\d+)?)/) {
+        $secs = $1 * 3600 + $2 * 60 + $3;
+      }
+      $output .= sprintf(
+        qq(netdisco_slow_device_duration_seconds{tenant="%s",device="%s",action="%s"} %.3f\n),
+        $tenant, $row->{device}, $row->{action}, $secs);
+    }
+  }
+  $output .= "\n";
+
+  # -- SNMP connect failures (DeviceSkip table) ------------------------------
+  $output .= _header('netdisco_snmp_failures_devices',
+    'Number of devices with at least one SNMP connect failure');
+  foreach my $tenant (@tenants) {
+    my $count = try {
+      schema($tenant)->resultset('DeviceSkip')->search({
+        deferrals => { '>' => 0 },
+        device    => { '!=' => '255.255.255.255' },
+      })->count;
+    } catch { 0 };
+    $output .= _sample('netdisco_snmp_failures_devices', $count, tenant => $tenant);
+  }
+  $output .= "\n";
+
+  $output .= _header('netdisco_snmp_failures_by_device',
+    'Number of SNMP connect failures per device and backend (top 50 by failure count)');
+  foreach my $tenant (@tenants) {
+    my @rows = try {
+      schema($tenant)->resultset('DeviceSkip')->search({
+        deferrals => { '>' => 0 },
+        device    => { '!=' => '255.255.255.255' },
+      }, {
+        order_by => { -desc => 'deferrals' },
+        rows     => 50,
+      })->hri->all;
+    } catch { () };
+    foreach my $row (@rows) {
+      $output .= sprintf(
+        qq(netdisco_snmp_failures_by_device{tenant="%s",device="%s",backend="%s"} %s\n),
+        $tenant, $row->{device}, $row->{backend}, $row->{deferrals});
+    }
+  }
+  $output .= "\n";
+
   return $output;
 };
 

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -1,0 +1,160 @@
+package App::Netdisco::Web::Metrics;
+
+use Dancer ':syntax';
+use Dancer::Plugin::DBIC;
+
+use App::Netdisco::Util::Permission 'acl_matches';
+use Try::Tiny;
+
+# Emit a gauge metric line with optional labels
+sub _gauge {
+  my ($name, $help, $value, %labels) = @_;
+  my $label_str = '';
+  if (%labels) {
+    $label_str = '{'. join(',', map { qq($_="$labels{$_}") } sort keys %labels) .'}';
+  }
+  return sprintf("# HELP %s %s\n# TYPE %s gauge\n%s%s %s\n",
+    $name, $help, $name, $name, $label_str, $value // 0);
+}
+
+get '/metrics' => sub {
+  # Optional IP range restriction
+  my $allow = setting('metrics_allow');
+  if ($allow and ref $allow eq ref []) {
+    my $remote = request->remote_address;
+    unless (acl_matches($remote, $allow)) {
+      status 403;
+      return 'Forbidden';
+    }
+  }
+
+  # Optional bearer token auth
+  my $token = setting('metrics_token');
+  if ($token) {
+    my $auth = request->header('Authorization') // '';
+    unless ($auth eq "Bearer $token") {
+      status 401;
+      header 'WWW-Authenticate' => 'Bearer realm="netdisco metrics"';
+      return 'Unauthorized';
+    }
+  }
+
+  content_type 'text/plain; version=0.0.4; charset=utf-8';
+
+  my @tenants = ('netdisco');
+  if (my $tdbs = setting('tenant_databases')) {
+    push @tenants, map { $_->{'tag'} } @$tdbs;
+  }
+
+  my $output = '';
+
+  # -- Statistics metrics (one row per tenant) -------------------------------
+  my %stat_metrics = (
+    netdisco_devices_total        => 'Total number of discovered devices',
+    netdisco_device_ips_total     => 'Total number of device IP addresses',
+    netdisco_device_links_total   => 'Total number of layer2 links between devices',
+    netdisco_device_ports_total   => 'Total number of device ports',
+    netdisco_device_ports_up      => 'Total number of device ports with up/up status',
+    netdisco_ip_table_total       => 'Total number of IP table entries',
+    netdisco_ip_active_total      => 'Total number of active IP entries',
+    netdisco_nodes_total          => 'Total number of node entries',
+    netdisco_nodes_active_total   => 'Total number of active nodes',
+    netdisco_phones_total         => 'Total number of discovered VoIP phones',
+    netdisco_waps_total           => 'Total number of discovered wireless access points',
+  );
+
+  my %stat_columns = (
+    netdisco_devices_total        => 'device_count',
+    netdisco_device_ips_total     => 'device_ip_count',
+    netdisco_device_links_total   => 'device_link_count',
+    netdisco_device_ports_total   => 'device_port_count',
+    netdisco_device_ports_up      => 'device_port_up_count',
+    netdisco_ip_table_total       => 'ip_table_count',
+    netdisco_ip_active_total      => 'ip_active_count',
+    netdisco_nodes_total          => 'node_table_count',
+    netdisco_nodes_active_total   => 'node_active_count',
+    netdisco_phones_total         => 'phone_count',
+    netdisco_waps_total           => 'wap_count',
+  );
+
+  foreach my $metric (sort keys %stat_metrics) {
+    $output .= sprintf("# HELP %s %s\n# TYPE %s gauge\n",
+      $metric, $stat_metrics{$metric}, $metric);
+
+    foreach my $tenant (@tenants) {
+      my $stats = try {
+        schema($tenant)->resultset('Statistics')
+          ->search(undef, { order_by => { -desc => 'day' }, rows => 1 })->first;
+      };
+      next unless $stats;
+      my $col = $stat_columns{$metric};
+      $output .= sprintf("%s{tenant=\"%s\"} %s\n",
+        $metric, $tenant, $stats->$col // 0);
+    }
+    $output .= "\n";
+  }
+
+  # -- Job queue metrics (live, per tenant) ----------------------------------
+  foreach my $tenant (@tenants) {
+    my $rs = try { schema($tenant)->resultset('Admin') } or next;
+
+    # Counts by status
+    foreach my $st (qw/queued done error/) {
+      my $count = try { $rs->search({ status => $st })->count } // 0;
+      $output .= _gauge('netdisco_jobs_total',
+        'Number of jobs in the queue by status',
+        $count, tenant => $tenant, status => $st);
+    }
+
+    # Running (queued + assigned to backend)
+    my $running = try {
+      $rs->search({ status => 'queued', backend => { '!=' => undef } })->count;
+    } // 0;
+    $output .= _gauge('netdisco_jobs_running',
+      'Number of jobs currently running',
+      $running, tenant => $tenant);
+
+    # Counts by action+status
+    $output .= "# HELP netdisco_jobs_by_action Number of jobs grouped by action and status\n";
+    $output .= "# TYPE netdisco_jobs_by_action gauge\n";
+    my @by_action = try {
+      $rs->search(undef, {
+        select   => ['action', 'status', { count => '*', -as => 'cnt' }],
+        as       => [qw/action status cnt/],
+        group_by => [qw/action status/],
+      })->hri->all;
+    } catch { () };
+
+    foreach my $row (@by_action) {
+      $output .= sprintf(qq(netdisco_jobs_by_action{tenant="%s",action="%s",status="%s"} %s\n),
+        $tenant, $row->{action}, $row->{status}, $row->{cnt});
+    }
+    $output .= "\n";
+
+    # Average duration of completed jobs by action (in seconds)
+    $output .= "# HELP netdisco_job_duration_seconds Average duration of completed jobs by action\n";
+    $output .= "# TYPE netdisco_job_duration_seconds gauge\n";
+    my @durations = try {
+      $rs->search(
+        { status => 'done', started => { '!=' => undef }, finished => { '!=' => undef } },
+        {
+          select   => ['action',
+            { avg => \"extract(epoch FROM (finished - started))", -as => 'avg_duration' }],
+          as       => [qw/action avg_duration/],
+          group_by => ['action'],
+        }
+      )->hri->all;
+    } catch { () };
+
+    foreach my $row (@durations) {
+      next unless defined $row->{avg_duration};
+      $output .= sprintf(qq(netdisco_job_duration_seconds{tenant="%s",action="%s"} %.3f\n),
+        $tenant, $row->{action}, $row->{avg_duration});
+    }
+    $output .= "\n";
+  }
+
+  return $output;
+};
+
+true;

--- a/lib/App/Netdisco/Web/Metrics.pm
+++ b/lib/App/Netdisco/Web/Metrics.pm
@@ -229,6 +229,43 @@ get '/metrics' => sub {
   }
   $output .= "\n";
 
+  # -- Stale discovery (devices not polled recently) ------------------------
+  foreach my $action (
+    [ netdisco_devices_discover_stale => 'last_discover' => 'Number of devices not discovered in the last 24 hours' ],
+    [ netdisco_devices_macsuck_stale  => 'last_macsuck'  => 'Number of devices not macsucked in the last 24 hours'  ],
+    [ netdisco_devices_arpnip_stale   => 'last_arpnip'   => 'Number of devices not arpniped in the last 24 hours'   ],
+  ) {
+    my ($metric, $col, $help) = @$action;
+    $output .= _header($metric, $help);
+    foreach my $tenant (@tenants) {
+      my $count = try {
+        schema($tenant)->resultset('Device')->search({
+          -or => [
+            $col => undef,
+            $col => { '<' => \q|(now() - interval '24 hours')| },
+          ],
+        })->count;
+      } catch { 0 };
+      $output .= _sample($metric, $count, tenant => $tenant);
+    }
+    $output .= "\n";
+  }
+
+  # -- Live MAC and ARP counts -----------------------------------------------
+  $output .= _header('netdisco_mac_entries', 'Live count of MAC address entries in the node table');
+  foreach my $tenant (@tenants) {
+    my $count = try { schema($tenant)->resultset('Node')->count } catch { 0 };
+    $output .= _sample('netdisco_mac_entries', $count, tenant => $tenant);
+  }
+  $output .= "\n";
+
+  $output .= _header('netdisco_arp_entries', 'Live count of ARP entries in the node_ip table');
+  foreach my $tenant (@tenants) {
+    my $count = try { schema($tenant)->resultset('NodeIp')->count } catch { 0 };
+    $output .= _sample('netdisco_arp_entries', $count, tenant => $tenant);
+  }
+  $output .= "\n";
+
   # -- Slow devices (top 20 per tenant, bounded cardinality) -----------------
   $output .= _header('netdisco_slow_device_duration_seconds',
     'Duration of last completed job for the 20 slowest devices by action (discover/macsuck/arpnip)');

--- a/share/environments/deployment.yml
+++ b/share/environments/deployment.yml
@@ -106,3 +106,21 @@ device_auth:
 # `````````````````````````````````````````````````````````
 #safe_password_store: true
 
+# enable a health check endpoint for use with load balancers and container
+# health probes (Docker, Kubernetes). returns JSON with db and backend status.
+# responds HTTP 200 when healthy, 503 when the database is unreachable.
+# no authentication is required. disabled by default.
+# ``````````````````````````````````````````````````````````````````````
+#health_path: '/health'
+
+# enable a Prometheus metrics endpoint for scraping inventory and job queue
+# statistics. disabled by default - set a path to enable.
+# metrics_token: require "Authorization: Bearer <token>" header if set.
+# metrics_allow: restrict by source IP, same format as other netdisco ACLs.
+# `````````````````````````````````````````````````````````````````````````
+#metrics_path: '/metrics'
+#metrics_token: 'changeme'
+#metrics_allow:
+#  - '127.0.0.0/8'
+#  - '::1'
+


### PR DESCRIPTION
Hi, first of all thanks for merging the statistics API — much appreciated! I hope this follow-up PR is welcome too. Happy to adjust anything that doesn't fit the project's direction.

So this adds two new optional endpoints, both **disabled by default** and enabled by setting their path in `deployment.yml`:

### `health_path: '/health'`
Endpoint returning JSON (`status`, `db`, `backends`, `workers`). Designed for load balancers, Docker/Kubernetes health probes and similar tooling. No authentication — intentionally open. Returns HTTP 503 if the database is unreachable.

```json
{"status":"ok","db":"ok","backends":2,"workers":16}
```

### `metrics_path: '/metrics'`

A VictoriaMetrics/Prometheus exposition format endpoint exposing:

**Inventory** (from the statistics table, daily snapshot):
- `netdisco_devices` — total discovered devices
- `netdisco_device_ports` / `netdisco_device_ports_up` — total and up ports
- `netdisco_nodes` / `netdisco_nodes_active` — node table and active nodes
- `netdisco_ip_table` / `netdisco_ip_active` — IP table and active IPs
- `netdisco_device_links` — layer2 links
- `netdisco_phones` / `netdisco_waps` — VoIP phones and access points
- `netdisco_stats_age_seconds` — age of the latest snapshot (useful to alert if stats job stops running)

**Live inventory:**
- `netdisco_mac_entries` / `netdisco_arp_entries` — live counts from node/node_ip tables
- `netdisco_devices_by_vendor` / `netdisco_devices_by_os` — device breakdown by vendor and OS
- `netdisco_devices_discover_stale` / `netdisco_devices_macsuck_stale` / `netdisco_devices_arpnip_stale` — devices not polled in the last 24h

**Job queue (live):**
- `netdisco_jobs{status}` — queue depth by status (queued/done/error)
- `netdisco_jobs_running` / `netdisco_jobs_stale` — running and stale jobs
- `netdisco_jobs_by_action{action,status}` — counts grouped by action and status
- `netdisco_job_duration_seconds{action}` — average duration of completed jobs by action

**Backend health:**
- `netdisco_backends` / `netdisco_workers` — active backends and worker slots
- `netdisco_snmp_failures_devices` — count of devices with SNMP connect failures
- `netdisco_snmp_failures_by_device{device,backend}` — failure count per device, top 50
- `netdisco_slow_device_duration_seconds{device,action}` — last job duration for the 20 slowest devices (reuses the existing `SlowDevices` view, bounded cardinality regardless of fleet size)

All metrics carry a `tenant` label for multi-tenant deployments.

Optional auth via bearer token and/or source IP ACL, so here sample config for both endpoints:

```yaml
health_path: '/health'
metrics_path: '/metrics'
metrics_token: 'changeme'
metrics_allow:
  - '127.0.0.0/8'
  - '::1'
```
I deliberately avoided adding any new CPAN dependencies. Two libraries I would favor:

- [`Net::Prometheus`](https://metacpan.org/pod/Net::Prometheus) 
- [`Prometheus::Tiny`](https://metacpan.org/pod/Prometheus::Tiny) 

The Prometheus text exposition format is simple and stable enough that a library adds little value here. If you'd prefer one of them I'm happy to adapt the implementation.

Mentionable that  `/health` and `/metrics` are exempted from the login `before` hook in `AuthN.pm` dynamically based on the configured paths, so no session is required to reach them.

Please let me know what you think and/or advice advise any change.  I will provide a full metrics, Grafana dashbaord and alert rules, I just have to collect more data :-) 

btw. I really appreciate the netdisco GUI as it already offers a good overview and strong reporting possibilities. This  metrics endpoint offers us a easy way to unify/centralize monitoring and alerting.  