### PR TITLE
Feature/api power modules

### DIFF
--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -23,7 +23,40 @@ swagger_path {
 }, get '/api/v1/object/device/:ip' => require_role api => sub {
   my $device = try { schema(vars->{'tenant'})->resultset('Device')
     ->find( params->{ip} ) } or send_error('Bad Device', 404);
-  return to_json $device->TO_JSON;
+
+  my $data = $device->TO_JSON;
+
+  my @modules = try {
+    schema(vars->{'tenant'})->resultset('DevicePower')
+      ->search({ 'me.ip' => $device->ip })->with_poestats->hri->all;
+  } catch { () };
+
+  if (@modules) {
+    my %totals = (
+      modules             => scalar @modules,
+      power_total         => 0,
+      poe_capable_ports   => 0,
+      poe_powered_ports   => 0,
+      poe_disabled_ports  => 0,
+      poe_errored_ports   => 0,
+      poe_power_committed => 0,
+      poe_power_delivering => 0,
+    );
+    for my $m (@modules) {
+      $totals{power_total}          += $m->{power}               // 0;
+      $totals{poe_capable_ports}    += $m->{poe_capable_ports}   // 0;
+      $totals{poe_powered_ports}    += $m->{poe_powered_ports}   // 0;
+      $totals{poe_disabled_ports}   += $m->{poe_disabled_ports}  // 0;
+      $totals{poe_errored_ports}    += $m->{poe_errored_ports}   // 0;
+      $totals{poe_power_committed}  += $m->{poe_power_committed} // 0;
+      $totals{poe_power_delivering} += $m->{poe_power_delivering} // 0;
+    }
+    $data->{poe} = \%totals;
+  } else {
+    $data->{poe} = undef;
+  }
+
+  return to_json $data;
 };
 
 foreach my $rel (qw/device_ips vlans ports modules port_vlans wireless_ports ssids powered_ports/) {

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -48,6 +48,28 @@ foreach my $rel (qw/device_ips vlans ports modules port_vlans wireless_ports ssi
 
 swagger_path {
   tags => ['Objects'],
+  path => (setting('api_base') || '').'/object/device/{ip}/power_modules',
+  description => 'Returns PoE module status and aggregated port statistics for a given device',
+  parameters  => [
+    ip => {
+      description => 'Canonical IP of the Device. Use Search methods to find this.',
+      required => 1,
+      in => 'path',
+    },
+  ],
+  responses => { default => {} },
+}, get '/api/v1/object/device/:ip/power_modules' => require_role api => sub {
+  my $device = try { schema(vars->{'tenant'})->resultset('Device')
+    ->find( params->{ip} ) } or send_error('Bad Device', 404);
+  my @rows = try {
+    schema(vars->{'tenant'})->resultset('DevicePower')
+      ->search({ 'me.ip' => $device->ip })->with_poestats->hri->all;
+  } catch { () };
+  return to_json \@rows;
+};
+
+swagger_path {
+  tags => ['Objects'],
   path => setting('api_base')."/object/device/{ip}/neighbors",
   description => 'Returns layer 2 neighbor relation data for a given device',
   parameters => [


### PR DESCRIPTION
Hi

Small follow-up to for API — adding PoE data exposure via the existing object API.

However, stupid me overlooked the `/devicepoestatus` :crying_cat_face: , haven't expect it under reports. so feel free to reject or suggest any change. My PR is a bit more granular and fits my use case better - or i don't understand how an unfiltered list of `devicepoestatus` is intended? 

### `GET /api/v1/object/device/:ip`

The device object now includes a `poe` summary field aggregating across all PoE modules: 
  ```json 
{
   "name":"foo.example.com"
    "last_macsuck":"2026-04-13 11:20:53.83211"
    "poe":{
      "poe_errored_ports":0
      "poe_capable_ports":48
      "poe_disabled_ports":0
      "poe_powered_ports":24
      "modules":2
      "poe_power_committed":765.4
      "power_total":1275
      "poe_power_delivering":302.1
    }
    "os_ver":"17.9.5"
```
poe is null for devices with no PoE modules. Uses the existing with_poestats window function query. if somebody sees performance issues, a dedicate /device/{ip}/poesummary might be better?

### `GET /api/v1/object/device/{ip}/power_modules`
Basically `devicepoestatus`but filtered:
```json
[
  {
    "module": 1,
    "poe_disabled_ports": 0,
    "power": 915,
    "poe_powered_ports": 24,
    "poe_errored_ports": 0,
    "poe_capable_ports": 24,
    "poe_power_delivering": "277.7",
    "ip": "172.28.236.213",
    "status": "on",
    "poe_power_committed": "705.4"
  },
  {
    "poe_errored_ports": 0,
    "poe_capable_ports": 24,
    "poe_disabled_ports": 0,
    "module": 2,
    "power": 360,
    "poe_powered_ports": 2,
    "status": "on",
    "poe_power_committed": "60.0",
    "ip": "172.28.236.213",
    "poe_power_delivering": "24.4"
  }
]
```