### PR TITLE
Fix numeric warning when job log is NULL in jobqueue template

### DIFF
--- a/share/views/ajax/admintask/jobqueue.tt
+++ b/share/views/ajax/admintask/jobqueue.tt
@@ -48,7 +48,7 @@
           <a href="[% uri_for('/device') | none %]?q=[% row.device | uri %]">[% row.target.dns || row.device | html_entity %]</a>
           [% END %]
         [% ELSE %]
-        <span title="[% row.log | html_entity %]">[% row.log.substr(0, 40) | html_entity %][% '...' IF row.log.length > 40 %]</span>
+        <span title="[% row.log | html_entity %]">[% row.log.substr(0, 40) | html_entity %][% '...' IF row.log AND row.log.length > 40 %]</span>
         [% END %]
       </td>
 


### PR DESCRIPTION
Fix this 
`Argument "" isn't numeric in numeric gt (>) at /home/netdisco/perl5/lib/perl5/auto/share/dist/App-Netdisco/views/ajax/admintask/jobqueue.tt line 51.`

which was introduced in #1493 - my bad. 