### PR TITLE
Conainer Logging to Sterr/stout in foreground mode 

### DIFF
--- a/bin/netdisco-backend
+++ b/bin/netdisco-backend
@@ -68,9 +68,14 @@ if (! -e $app_config) {
 my $netdisco = file($FindBin::RealBin, 'netdisco-backend-fg');
 my @args = (scalar @ARGV > 1 ? @ARGV[1 .. $#ARGV] : ());
 
+my $foreground = (@ARGV and $ARGV[0] eq 'foreground');
+
 my $log_dir = dir($home, 'logs');
-mkdir $log_dir if ! -d $log_dir;
-my $log_file = file($log_dir, 'netdisco-backend.log');
+my $log_file;
+if (!$foreground) {
+  mkdir $log_dir if ! -d $log_dir;
+  $log_file = file($log_dir, 'netdisco-backend.log');
+}
 
 my $uid = (stat($netdisco->stringify))[4] || 0;
 my $gid = (stat($netdisco->stringify))[5] || 0;
@@ -84,8 +89,10 @@ Daemon::Control->new({
   program  => \&restarter,
   program_args => [@args],
   pid_file => $new_pid,
-  stderr_file => $log_file,
-  stdout_file => $log_file,
+  ($foreground ? () : (
+    stderr_file => $log_file,
+    stdout_file => $log_file,
+  )),
   redirect_before_fork => 0,
   uid => $uid, gid => $gid,
 })->run;
@@ -99,7 +106,10 @@ sub restarter {
   $child = fork_and_start($daemon, @program_args);
   exit(1) unless $child;
 
-  my $watcher = Filesys::Notify::Simple->new([$ENV{DANCER_ENVDIR}, $log_dir]);
+  my $watcher = Filesys::Notify::Simple->new([
+    $ENV{DANCER_ENVDIR},
+    ($foreground ? () : $log_dir),
+  ]);
   warn "config watcher: watching $ENV{DANCER_ENVDIR} for updates.\n";
 
   local $SIG{TERM} = sub { $child = signal_child('TERM', $child); exit(0); };
@@ -110,7 +120,7 @@ sub restarter {
       # this is blocking
       $watcher->wait(sub {
           my @events = @_;
-          @events = grep {$_->{path} eq $log_file or
+          @events = grep {($log_file and $_->{path} eq $log_file) or
                           file($_->{path})->basename eq $config} @events;
           return unless @events;
           @restart = @events;
@@ -120,7 +130,7 @@ sub restarter {
       next unless @restart;
 
       foreach my $f (@restart) {
-          if ($f->{path} eq $log_file) {
+          if ($log_file and $f->{path} eq $log_file) {
               ++$rotate;
           }
           else {

--- a/bin/netdisco-web
+++ b/bin/netdisco-web
@@ -73,18 +73,23 @@ if (exists $ENV{PORT} and 0 == scalar grep { $_ =~ m/port/ } @args) {
     push @args, "--port=$ENV{PORT}";
 }
 
+my $foreground = (@ARGV and $ARGV[0] eq 'foreground');
+
 my $uid = (stat($netdisco->stringify))[4] || 0;
 my $gid = (stat($netdisco->stringify))[5] || 0;
 
 my $log_dir = dir($home, 'logs');
-mkdir $log_dir if ! -d $log_dir;
-chown $uid, $gid, $log_dir;
+my $log_file;
+if (!$foreground) {
+  mkdir $log_dir if ! -d $log_dir;
+  chown $uid, $gid, $log_dir;
+  $log_file = file($log_dir, 'netdisco-web.log');
+}
 
 my $pid_file = file($home, 'netdisco-web.pid');
-my $log_file = file($log_dir, 'netdisco-web.log');
 
 # change ownership of key files to be netdisco user
-foreach my $file ($pid_file, $log_file) {
+foreach my $file ($pid_file, ($foreground ? () : $log_file)) {
     unless (-e $file) {
         sysopen my $fh, $file, O_WRONLY|O_CREAT|O_NONBLOCK|O_NOCTTY;
         print $fh '0' if $file eq $pid_file;
@@ -106,8 +111,10 @@ Daemon::Control->new({
     @args, $netdisco->stringify
   ],
   pid_file => $pid_file,
-  stderr_file => $log_file,
-  stdout_file => $log_file,
+  ($foreground ? () : (
+    stderr_file => $log_file,
+    stdout_file => $log_file,
+  )),
   redirect_before_fork => 0,
   ((scalar grep { $_ =~ m/port/ } @args) ? ()
                                          : (uid => $uid, gid => $gid)),
@@ -121,7 +128,10 @@ sub restarter {
   my $child = fork_and_start($daemon, @program_args);
   exit(1) unless $child;
 
-  my $watcher = Filesys::Notify::Simple->new([$ENV{DANCER_ENVDIR}, $log_dir]);
+  my $watcher = Filesys::Notify::Simple->new([
+    $ENV{DANCER_ENVDIR},
+    ($foreground ? () : $log_dir),
+  ]);
   warn "config watcher: watching $ENV{DANCER_ENVDIR} for updates.\n";
 
   # TODO: starman also supports TTIN,TTOU,INT,QUIT
@@ -134,7 +144,7 @@ sub restarter {
       # this is blocking
       $watcher->wait(sub {
           my @events = @_;
-          @events = grep {$_->{path} eq $log_file or
+          @events = grep {($log_file and $_->{path} eq $log_file) or
                           file($_->{path})->basename eq $config} @events;
           return unless @events;
           @restart = @events;
@@ -144,7 +154,7 @@ sub restarter {
       next unless @restart;
 
       foreach my $f (@restart) {
-          if ($f->{path} eq $log_file) {
+          if ($log_file and $f->{path} eq $log_file) {
               ++$rotate;
           }
           else {


### PR DESCRIPTION

This addresses the logging issue on container/k8s/RHOS envs

- Detects when `netdisco-backend` / `netdisco-web` are started with the `foreground` subcommand (as used by the Docker images)                                                  
 - In foreground mode: skips creating `~/logs/`, skips setting `stderr_file`/`stdout_file` in `Daemon::Control`, and skips watching the log dir for rotation events
- In daemon mode (`start`/`stop`/`restart`): behaviour is completely unchanged

after that the docker symlink fix  or mount can be removed. 

for transparency, this code is a bit Improvised, a review would be beneficial. Works in my docker env: 

```
netdisco-web         | config watcher: sending TERM to the web server (pid:8)...
netdisco-web exited with code 0 (restarting)
netdisco-web         | config watcher: watching /home/netdisco/environments for updates.
netdisco-web         | 2026/04/20-19:53:41 Starman::Server (type Net::Server::PreFork) starting! pid(8)
netdisco-web         | Binding to TCP port 5000 on host * with IPv4
netdisco-web         | [12] 2026-04-20 19:53:44  warn App::Netdisco 2.097003 web
netdisco-web         | [9] 2026-04-20 19:53:44  warn App::Netdisco 2.097003 web
netdisco-web         | [11] 2026-04-20 19:53:44  warn App::Netdisco 2.097003 web
netdisco-web         | [13] 2026-04-20 19:53:45  warn App::Netdisco 2.097003 web
netdisco-web         | [10] 2026-04-20 19:53:45  warn App::Netdisco 2.097003 web
netdisco-postgresql  | 2026-04-20 19:53:55.380 UTC [133] LOG:  checkpoint complete: wrote 3775 buffers (23.0%), wrote 3 SLRU buffers; 0 WAL file(s) added, 0 removed, 3 recycled; write=269.072 s, sync=0.236 s, total=269.587 s; sync files=309, longest=0.006 s, average=0.001 s; distance=46463 kB, estimate=46463 kB; lsn=0/491E4A0, redo lsn=0/4900390
netdisco-backend     | config watcher: sending TERM to the server (pid:9)...
netdisco-backend exited with code 0 (restarting)
netdisco-backend     | config watcher: watching /home/netdisco/environments for updates.
netdisco-backend     | [8] 2026-04-20 19:54:18  warn App::Netdisco 2.097003 backend
```

edit: discuss what to do with `~/logs/snapshots`