### PR TITLE
fixes #1497 - numeric warning when nodes list is empty in ports template

### DIFF
--- a/share/views/ajax/device/ports.tt
+++ b/share/views/ajax/device/ports.tt
@@ -429,9 +429,9 @@
           [% END %]
         [% END %]
         [% IF params.c_nodes %]
-        [% IF (row.$nodes.max + 1) > settings.devport_nodes_collapse_threshold %]
+        [% IF row.$nodes.size > settings.devport_nodes_collapse_threshold %]
         <div class="nd_nodes-total">
-          <strong>[% row.$nodes.max + 1 %] nodes</strong>
+          <strong>[% row.$nodes.size %] nodes</strong>
           <span class="nd_collapse-vlans">
             Show <div class="nd_arrow-up-down-left-down icon-plus-sign-alt"></div>&nbsp;
           </span>
@@ -497,7 +497,7 @@
             [% END %]
           [% END %]
         [% END %]
-        [% IF (row.$nodes.max + 1) > settings.devport_nodes_collapse_threshold %]
+        [% IF row.$nodes.size > settings.devport_nodes_collapse_threshold %]
         </div>
         [% END %]
         [% END %]


### PR DESCRIPTION
Fixes #1497

When `params.c_nodes` is enabled but a row has no nodes, `row.$nodes.max` returns undef, and the template expression `(row.$nodes.max + 1)` triggers a "Argument isn't numeric in addition" warning.                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
Switch to `row.$nodes.size`, which is well-defined for empty lists and also reads more clearly (it's the actual count of nodes, not max-index + 1)

This was first fixed in #1499 (also applies to ports.tt) but in favor of simplification I pealed it out  into this dedicated PR