### PR TITLE
skip privilege drop when already running unprivileged

### DIFF
--- a/bin/netdisco-backend
+++ b/bin/netdisco-backend
@@ -80,6 +80,11 @@ if (!$foreground) {
 my $uid = (stat($netdisco->stringify))[4] || 0;
 my $gid = (stat($netdisco->stringify))[5] || 0;
 
+# only drop privileges if we are root; otherwise we cannot setuid anyway
+# and Daemon::Control would emit a misleading "Operation not permitted"
+# warning under e.g. OpenShift random UIDs.
+my $can_drop_priv = ($> == 0);
+
 my $old_pid = file($home, 'netdisco-daemon.pid');
 my $new_pid = file($home, 'netdisco-backend.pid');
 if (-f $old_pid) { File::Copy::move( $old_pid, $new_pid ) }
@@ -94,7 +99,7 @@ Daemon::Control->new({
     stdout_file => $log_file,
   )),
   redirect_before_fork => 0,
-  uid => $uid, gid => $gid,
+  ($can_drop_priv ? (uid => $uid, gid => $gid) : ()),
 })->run;
 
 # the guts of this are borrowed from Plack::Loader::Restarter - many thanks!!

--- a/bin/netdisco-web
+++ b/bin/netdisco-web
@@ -78,6 +78,11 @@ my $foreground = (@ARGV and $ARGV[0] eq 'foreground');
 my $uid = (stat($netdisco->stringify))[4] || 0;
 my $gid = (stat($netdisco->stringify))[5] || 0;
 
+# only drop privileges if we are root; otherwise we cannot setuid anyway
+# and Daemon::Control / starman would emit a misleading
+# "Operation not permitted" warning under e.g. OpenShift random UIDs.
+my $can_drop_priv = ($> == 0);
+
 my $log_dir = dir($home, 'logs');
 my $log_file;
 if (!$foreground) {
@@ -107,7 +112,7 @@ Daemon::Control->new({
   program  => \&restarter,
   program_args => [
     '--disable-keepalive',
-    '--user', $uid, '--group', $gid,
+    ($can_drop_priv ? ('--user', $uid, '--group', $gid) : ()),
     @args, $netdisco->stringify
   ],
   pid_file => $pid_file,
@@ -116,8 +121,8 @@ Daemon::Control->new({
     stdout_file => $log_file,
   )),
   redirect_before_fork => 0,
-  ((scalar grep { $_ =~ m/port/ } @args) ? ()
-                                         : (uid => $uid, gid => $gid)),
+  (($can_drop_priv and 0 == scalar grep { $_ =~ m/port/ } @args)
+    ? (uid => $uid, gid => $gid) : ()),
 })->run;
 
 # the guts of this are borrowed from Plack::Loader::Restarter - many thanks!!


### PR DESCRIPTION
`bin/netdisco-web` and `bin/netdisco-backend` both pass `uid` / `gid` to `Daemon::Control`, which then calls `setuid(2)`/`setgid(2)`. When the daemons are started as a non-root user — typical of any container deployment, and required under OpenShift's `restricted-v2` SCC where every pod runs as a random UID — the setuid call fails with `EPERM` and `Daemon::Control` (and starman, in the web case) print a misleading warning:

```
Setting gid to "0 0 0"
Setting uid to "901"
Couldn't become uid "901": Operation not permitted
```

The warning is non-fatal — workers fork and the daemon continues to serve traffic — but it's noisy and looks like something is broken when nothing actually is.

The fix is to guard the `uid` / `gid` arguments to `Daemon::Control` on `$> == 0`. There is nothing to drop privileges *to* if we are not root in the first place. Same guard for starman's `--user` / `--group` flags in `netdisco-web`'s `program_args`.

If I got it right it has no inpact on:
- Running as root (traditional package install, systemd unit started with no `User=` directive): unchanged. `$> == 0` so the existing privilege drop still happens.
- Running as the netdisco user via `docker compose` (uid 901, the file owner): warnings disappear; the daemon was already running as the desired uid so there was nothing to do anyway.
- Running under OpenShift random UID: warnings disappear; the daemon continues to run as the random UID, which is what we want.

Testing:
- [ ] `docker compose up` boots cleanly, no privilege-drop warnings in logs
- [ ] `docker run --user 1000050000 ... netdisco-web foreground` starts cleanly, no warning
- [ ] If you have a setup running netdisco as root, confirm starman workers still drop to the netdisco user as before