### PR TITLE
show snmp auth tag in try_connect debug output

### DIFF
--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -299,10 +299,11 @@ sub _try_connect {
 
   try {
       $snmp_args->{Offline} || debug
-        sprintf '[%s:%s] try_connect with v: %s, t: %s, r: %s, class: %s, comm: %s',
+        sprintf '[%s:%s] try_connect with v: %s, t: %s, r: %s, class: %s%s, comm: %s',
           $snmp_args->{DestHost}, $snmp_args->{RemotePort},
           $snmp_args->{Version}, ($snmp_args->{Timeout} / 1000000), $snmp_args->{Retries},
-          $class, $debug_comm;
+          $class,
+          ($comm->{tag} ? ', tag: '. $comm->{tag} : ''), $debug_comm;
       Module::Load::load $class;
 
       $info = $class->new(%$snmp_args, %comm_args) or return;


### PR DESCRIPTION
When many communities/tags are configured, the debug output is confusing without knowing which tag was used for a connection attempt. This adds the auth tag (if set) to the `try_connect` debug line. so like: 

Before: 
```
try_connect with v: 2, t: 0.2, r: 0, class: SNMP::Info, comm: <hidden>
try_connect with v: 2, t: 0.2, r: 0, class: SNMP::Info, comm: <hidden>
```
Afer: 
```
try_connect with v: 2, t: 0.2, r: 0, class: SNMP::Info, tag: BranchDevices, comm: <hidden>
try_connect with v: 2, t: 0.2, r: 0, class: SNMP::Info, tag: CORE, comm: <hidden>
```


**Note to myself:** use `ND2_SHOW_COMMUNITY=1` to also reveal the community/v3 credentials in the output.