### PR TITLE
Add per-job param to discover via subaction

### DIFF
--- a/lib/App/Netdisco/Backend/Job.pm
+++ b/lib/App/Netdisco/Backend/Job.pm
@@ -1,6 +1,6 @@
 package App::Netdisco::Backend::Job;
 
-use Dancer qw/:moose :syntax !error/;
+use Dancer qw/:moose :syntax !error !params/;
 use aliased 'App::Netdisco::Worker::Status';
 
 use Moo;

--- a/lib/App/Netdisco/Backend/Job.pm
+++ b/lib/App/Netdisco/Backend/Job.pm
@@ -4,6 +4,7 @@ use Dancer qw/:moose :syntax !error/;
 use aliased 'App::Netdisco::Worker::Status';
 
 use Moo;
+use Try::Tiny;
 use Term::ANSIColor qw(:constants :constants256);
 use namespace::clean;
 
@@ -226,5 +227,18 @@ priority of the job and is used by L<MCE> when managing its job queue.
 =cut
 
 sub extra { (shift)->subaction }
+
+=head2 params
+
+Parses the C<subaction> field as JSON and returns a hashref of parameters.
+Returns an empty hashref if subaction is empty or not valid JSON.
+
+=cut
+
+sub params {
+  my $job = shift;
+  return {} unless $job->subaction;
+  return try { from_json($job->subaction) } catch { {snmp_tag => $job->subaction} };
+}
 
 true;

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -258,8 +258,8 @@ sub _snmp_connect_generic {
 
   # then revert to conservative settings and repeat with all versions
 
-  # unless user wants just the fast connections for bulk discovery
-  # or we are on the first discovery attempt of a new device
+  # unless user wants just the fast connections for bulk discovery
+  # or we are on the first discovery attempt of a new device
   return if setting('snmp_try_slow_connect') == false;
 
   CLASS: foreach my $class (@classes) {

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -299,10 +299,11 @@ sub _try_connect {
 
   try {
       $snmp_args->{Offline} || debug
-        sprintf '[%s:%s] try_connect with v: %s, t: %s, r: %s, class: %s, comm: %s',
+        sprintf '[%s:%s] try_connect with v: %s, t: %s, r: %s, class: %s%s, comm: %s',
           $snmp_args->{DestHost}, $snmp_args->{RemotePort},
           $snmp_args->{Version}, ($snmp_args->{Timeout} / 1000000), $snmp_args->{Retries},
-          $class, $debug_comm;
+          $class,
+          ($comm->{tag} ? ', tag: '. $comm->{tag} : ''), $debug_comm;
       Module::Load::load $class;
 
       $info = $class->new(%$snmp_args, %comm_args) or return;

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -56,7 +56,7 @@ Returns C<undef> if the connection fails.
 =cut
 
 sub reader_for {
-  my ($class, $ip, $useclass) = @_;
+  my ($class, $ip, $useclass, $tag_hint) = @_;
   my $device = get_device($ip) or return undef;
 
   my $readers = $class->instance->readers or return undef;
@@ -64,7 +64,7 @@ sub reader_for {
 
   debug sprintf 'snmp reader cache warm: [%s]', $device->ip;
   return ($readers->{$device->ip}
-    = _snmp_connect_generic('read', $device, $useclass));
+    = _snmp_connect_generic('read', $device, $useclass, $tag_hint));
 }
 
 =head1 test_connection( $ip )
@@ -122,7 +122,7 @@ sub writer_for {
 }
 
 sub _snmp_connect_generic {
-  my ($mode, $device, $useclass) = @_;
+  my ($mode, $device, $useclass, $tag_hint) = @_;
   $mode ||= 'read';
 
   my %snmp_args = (
@@ -185,7 +185,7 @@ sub _snmp_connect_generic {
   # get the community string(s)
   my @communities = $snmp_args{Offline}
     ? ({read => 1, write => 0, only => $device->ip, community => 'public'})
-    : get_communities($device, $mode);
+    : get_communities($device, $mode, $tag_hint);
 
   # which SNMP versions to try and in what order
   my @versions =
@@ -207,7 +207,7 @@ sub _snmp_connect_generic {
   my $tag_name = 'snmp_auth_tag_'. $mode;
   my $stored_tag = eval { $device->community->$tag_name };
 
-  if ($device->in_storage and $stored_tag) {
+  if (!$tag_hint and $device->in_storage and $stored_tag) {
       debug sprintf '[%s:%s] try_connect with cached tag %s',
           $snmp_args{DestHost}, $snmp_args{RemotePort}, $stored_tag;
 

--- a/lib/App/Netdisco/Util/SNMP.pm
+++ b/lib/App/Netdisco/Util/SNMP.pm
@@ -34,20 +34,29 @@ subroutines.
 
 =head1 EXPORT_OK
 
-=head2 get_communities( $device, $mode )
+=head2 get_communities( $device, $mode, $tag_hint? )
 
 Takes the current C<device_auth> setting and pushes onto the front of the list
 the last known good SNMP settings used for this mode (C<read> or C<write>).
 
+If C<$tag_hint> is provided, only C<device_auth> entries whose C<tag> matches
+are returned, skipping all others. Falls back to normal behaviour if no entry
+with that tag exists in the config.
+
 =cut
 
 sub get_communities {
-  my ($device, $mode) = @_;
+  my ($device, $mode, $tag_hint) = @_;
   $mode ||= 'read';
 
   my $seen_tags = {}; # for cleaning community table
   my $config = (setting('device_auth') || []);
   my @communities = ();
+
+  if ($tag_hint) {
+    my @tagged = grep { $_->{tag} and $_->{tag} eq $tag_hint } @$config;
+    return @tagged if @tagged;
+  }
 
   # first of all, use external command if configured
   push @communities, get_external_credentials($device, $mode);

--- a/lib/App/Netdisco/Web/API/Queue.pm
+++ b/lib/App/Netdisco/Web/API/Queue.pm
@@ -151,7 +151,7 @@ swagger_path {
             extra => {
               type => 'string',
               required => 0,
-              description => 'Optional job parameter. For discover: a plain string or JSON object. Plain string is treated as snmp_tag (e.g. "site-a-creds"). JSON allows named params, e.g. {"snmp_tag": "site-a-creds"}. The snmp_tag value must match a tag set on a device_auth entry in the configuration.',
+              description => 'Optional job parameter. For discover: a plain string or JSON object. Plain string is treated as snmp_tag. Supported JSON params: snmp_tag (string, must match a tag in device_auth), snmptimeout (integer, microseconds, overrides global snmptimeout), snmpretries (integer, overrides global snmpretries), bulkwalk_repeaters (integer, overrides global bulkwalk_repeaters), skip_neighbor_queue (bool, store topology but do not queue new discovers for unknown neighbors). Example: {"snmp_tag": "site-a", "snmptimeout": 3000000, "skip_neighbor_queue": true}.',
             }
           }
         }

--- a/lib/App/Netdisco/Web/API/Queue.pm
+++ b/lib/App/Netdisco/Web/API/Queue.pm
@@ -151,6 +151,7 @@ swagger_path {
             extra => {
               type => 'string',
               required => 0,
+              description => 'Optional job parameter. For discover: a plain string or JSON object. Plain string is treated as snmp_tag (e.g. "site-a-creds"). JSON allows named params, e.g. {"snmp_tag": "site-a-creds"}. The snmp_tag value must match a tag set on a device_auth entry in the configuration.',
             }
           }
         }

--- a/lib/App/Netdisco/Web/API/Queue.pm
+++ b/lib/App/Netdisco/Web/API/Queue.pm
@@ -141,6 +141,7 @@ swagger_path {
             action => {
               type => 'string',
               required => 1,
+              description => 'Job action. Known actions: discover, macsuck, arpnip, nbtstat, delete. Unknown actions are accepted but will fail silently in the backend.',
             },
             device => {
               type => 'string',

--- a/lib/App/Netdisco/Web/API/Queue.pm
+++ b/lib/App/Netdisco/Web/API/Queue.pm
@@ -6,6 +6,8 @@ use Dancer::Plugin::Swagger;
 use Dancer::Plugin::Auth::Extensible;
 
 use App::Netdisco::JobQueue 'jq_insert';
+use App::Netdisco::Util::DNS 'ipv4_from_hostname';
+use NetAddr::IP::Lite;
 use Try::Tiny;
 
 swagger_path {
@@ -174,12 +176,19 @@ swagger_path {
         if ($job->{action} =~ m/^cf_/ and not user_has_role('port_control'))
         or ($job->{action} !~ m/^cf_/ and not user_has_role('api_admin'));
 
+      if ($job->{device} and not NetAddr::IP::Lite->new($job->{device})) {
+          my $ip = ipv4_from_hostname($job->{device})
+            or return send_error("Cannot resolve hostname: $job->{device}", 400);
+          $job->{device} = $ip;
+      }
+
       $job->{username} = session('logged_in_user');
       $job->{userip}   = request->remote_address;
   }
 
   my $happy = jq_insert($jobs);
 
+  return send_error('Failed to insert jobs - check backend logs', 500) unless $happy;
   return to_json { success => $happy };
 };
 

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Neighbors.pm
@@ -70,6 +70,12 @@ register_worker({ phase => 'main', driver => 'snmp' }, sub {
       my $newdev = get_device($ip);
       next if $newdev->in_storage;
 
+      if ($job->params->{skip_neighbor_queue}) {
+          debug sprintf ' [%s] queue - skip_neighbor_queue: not queuing %s',
+            $device, $ip;
+          next;
+      }
+
       # risk of things going wrong...?
       # https://quickview.cloudapps.cisco.com/quickview/bug/CSCur12254
 

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -27,7 +27,8 @@ register_worker({ phase => 'early', driver => 'snmp',
   my ($job, $workerconf) = @_;
 
   my $device = $job->device;
-  my $snmp = App::Netdisco::Transport::SNMP->reader_for($device)
+  my $snmp = App::Netdisco::Transport::SNMP->reader_for(
+      $device, undef, $job->params->{snmp_tag})
     or return Status->defer("discover failed: could not SNMP connect to $device");
 
   # for field_protection

--- a/lib/App/Netdisco/Worker/Plugin/Internal/SNMPFastDiscover.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Internal/SNMPFastDiscover.pm
@@ -9,7 +9,24 @@ use Scalar::Util 'blessed';
 register_worker({ phase => 'check', driver => 'direct' }, sub {
   my ($job, $workerconf) = @_;
 
-  # if the job is a queued job, and discover, and the first one...
+  my $params = $job->params;
+
+  if ($params->{snmptimeout}) {
+      config->{'snmptimeout'} = $params->{snmptimeout};
+      debug sprintf "using per-job snmptimeout: %s", $params->{snmptimeout};
+  }
+
+  if ($params->{snmpretries}) {
+      config->{'snmpretries'} = $params->{snmpretries};
+      debug sprintf "using per-job snmpretries: %s", $params->{snmpretries};
+  }
+
+  if ($params->{bulkwalk_repeaters}) {
+      config->{'bulkwalk_repeaters'} = $params->{bulkwalk_repeaters};
+      debug sprintf "using per-job bulkwalk_repeaters: %s", $params->{bulkwalk_repeaters};
+  }
+
+  # if the job is a queued job, and discover, and the first one...
   if ($job->job and $job->action eq 'discover' and not $job->log
       and (not blessed $job->device or not $job->device->in_storage)) {
 
@@ -17,7 +34,7 @@ register_worker({ phase => 'check', driver => 'direct' }, sub {
       debug "running with fast SNMP timeouts for initial discover";
   }
   else {
-      debug "running with configured SNMP timeouts";
+      debug "running with configured SNMP timeouts" unless $params->{snmptimeout};
   }
 });
 


### PR DESCRIPTION

In environments with many mixed SNMP v3 credential profiles, the fast-pass (200ms per credential) fails for the correct credential because the device gets overwhelmed by rapid auth attempts before it is reached. Also related to #1422.

It also provides a non-destructive fix for the "stuck on wrong community string" scenario described in the Troubleshooting wiki: instead of deleting and re-discovering a device, you can force a discover with the correct tag to update the cached credential.

#### Supported `extra` params for discover

A plain string is treated as `snmp_tag` shorthand. JSON allows any combination of the following:

| param | type | description |
|---|---|---|
| `snmp_tag` | string | Use only the `device_auth` entry with this tag; skip all others and bypass cached-tag fast-probe. Must match a tag defined in `device_auth` config. |
| `snmptimeout` | integer (µs) | Override global `snmptimeout` for this job. Useful for high-latency or satellite-linked devices. |
| `snmpretries` | integer | Override global `snmpretries` for this job. |
| `bulkwalk_repeaters` | integer | Override global `bulkwalk_repeaters` for this job. Useful to reduce UDP fragmentation on high-latency links. |
| `skip_neighbor_queue` | bool | Store neighbor topology but do not queue new discovers for unknown neighbors. Prevents recursive discover cascades when manually triggering a one-off discover. |

## Usage

```bash
# plain string shorthand (snmp_tag only)
netdisco-do discover -d 192.0.2.1 -e site-a-creds

# explicit JSON with multiple params
netdisco-do discover -d 192.0.2.1 -e '{"snmp_tag": "site-a-creds"}'
netdisco-do discover -d 192.0.2.1 -e '{"snmptimeout": 3000000, "bulkwalk_repeaters": 5}'
netdisco-do discover -d 192.0.2.1 -e '{"snmp_tag": "site-a", "skip_neighbor_queue": true}'
```

```python
requests.post('/api/v1/queue/jobs',
  json=[{"action": "discover", "device": "192.0.2.1", "extra": "site-a-creds"}])

requests.post('/api/v1/queue/jobs',
  json=[{"action": "discover", "device": "192.0.2.1",
         "extra": '{"snmptimeout": 3000000, "skip_neighbor_queue": true}'}])
```

## Tests / Todo

- [x] Discover a device with `-e <tag>` and confirm only that credential is tried in debug log
- [x] Discover with JSON `-e '{"snmp_tag": "..."}'` and confirm same
- [x] Discover without `-e` and confirm normal credential cycling behaviour is unchanged
- [x] Discover with an unknown tag and confirm fallback to normal behaviour
- [ ] Confirm "stuck on wrong community" scenario resolves without deleting the device
- [x] Discover a high-latency device via queued job and confirm slow connect fallback runs
- [x] Discover with `skip_neighbor_queue: true` and confirm neighbors are stored but none queued
- [ ]  Wiki Update