### PR TITLE
add permanent API tokens and (dummy) Bearer auth support

### DIFF
--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -518,11 +518,21 @@ L<App::Netdisco::Worker::Plugin::MakeRancidConf> for configuration needs.
 
 =head2 getapikey
 
-Generates an API key for the supplied username. See the 
-L<API doc|https://github.com/netdisco/netdisco/wiki/API> for further 
+Generates an API key for the supplied username. See the
+L<API doc|https://github.com/netdisco/netdisco/wiki/API> for further
 information.
 
- ~/bin/netdisco-do getapikey -e the_username 
+ ~/bin/netdisco-do getapikey -e the_username
+
+To create a permanent token (no expiry) pass C<permanent> in the C<-p> parameter.
+The token can be used in the C<Authorization: Bearer E<lt>tokenE<gt>> HTTP header
+and is accepted by any tool supporting standard Bearer authentication (Grafana, curl, etc.).
+
+ ~/bin/netdisco-do getapikey -e the_username -p permanent
+
+To revoke all API tokens for a user:
+
+ ~/bin/netdisco-do getapikey -e the_username -p revoke
 
 =head2 dumpconfig
 

--- a/lib/App/Netdisco/DB.pm
+++ b/lib/App/Netdisco/DB.pm
@@ -11,7 +11,7 @@ __PACKAGE__->load_namespaces(
 );
 
 our # try to hide from kwalitee
-  $VERSION = 96; # schema version used for upgrades, keep as integer
+  $VERSION = 97; # schema version used for upgrades, keep as integer
 
 use Path::Class;
 use File::ShareDir 'dist_dir';

--- a/lib/App/Netdisco/DB/Result/User.pm
+++ b/lib/App/Netdisco/DB/Result/User.pm
@@ -45,6 +45,8 @@ __PACKAGE__->add_columns(
   { data_type => "boolean", default_value => \"false", is_nullable => 1 },
   "token_allowed_ips",
   { data_type => "text[]", is_nullable => 1 },
+  "token_auth_only",
+  { data_type => "boolean", default_value => \"false", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("username");
 

--- a/lib/App/Netdisco/DB/Result/User.pm
+++ b/lib/App/Netdisco/DB/Result/User.pm
@@ -43,6 +43,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "token_no_expire",
   { data_type => "boolean", default_value => \"false", is_nullable => 1 },
+  "token_allowed_ips",
+  { data_type => "text[]", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("username");
 

--- a/lib/App/Netdisco/DB/Result/User.pm
+++ b/lib/App/Netdisco/DB/Result/User.pm
@@ -41,6 +41,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "note",
   { data_type => "text", is_nullable => 1 },
+  "token_no_expire",
+  { data_type => "boolean", default_value => \"false", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("username");
 

--- a/lib/App/Netdisco/DB/Result/Virtual/UserRole.pm
+++ b/lib/App/Netdisco/DB/Result/Virtual/UserRole.pm
@@ -28,11 +28,13 @@ __PACKAGE__->result_source_instance->view_definition(<<ENDSQL
   UNION
   SELECT username, 'api' AS role FROM users
     WHERE ( ? ::boolean = false ) OR
+          token_no_expire = true OR
           ( token IS NOT NULL AND token_from IS NOT NULL
           AND token_from > (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) - ?) )
   UNION
   SELECT username, 'api_admin' AS role FROM users
     WHERE admin AND (( ? ::boolean = false ) OR
+          token_no_expire = true OR
           ( token IS NOT NULL AND token_from IS NOT NULL
           AND token_from > (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) - ?) ))
 ENDSQL

--- a/lib/App/Netdisco/Web.pm
+++ b/lib/App/Netdisco/Web.pm
@@ -131,6 +131,7 @@ use App::Netdisco::Web::Report;
 use App::Netdisco::Web::API::Objects;
 use App::Netdisco::Web::API::Queue;
 use App::Netdisco::Web::API::Statistics;
+use App::Netdisco::Web::API::User;
 use App::Netdisco::Web::Health;
 use App::Netdisco::Web::Metrics;
 use App::Netdisco::Web::AdminTask;

--- a/lib/App/Netdisco/Web/API/User.pm
+++ b/lib/App/Netdisco/Web/API/User.pm
@@ -9,6 +9,38 @@ use Try::Tiny;
 
 swagger_path {
   tags => ['User'],
+  path => (setting('api_base') || '').'/users',
+  description => 'List all users with their roles and token status',
+  responses => { default => {} },
+}, get '/api/v1/users' => require_role api_admin => sub {
+  header('Content-Type' => 'application/json');
+
+  my @users = schema(vars->{'tenant'})->resultset('User')->search(undef, {
+    '+columns' => { token_hint => \"right(token, 8)" },
+    order_by => 'username',
+  })->hri->all;
+
+  my @result = map {{
+    username        => $_->{username},
+    fullname        => $_->{fullname},
+    note            => $_->{note},
+    admin           => $_->{admin}  ? \1 : \0,
+    port_control    => $_->{port_control} ? \1 : \0,
+    ldap            => $_->{ldap}   ? \1 : \0,
+    radius          => $_->{radius} ? \1 : \0,
+    tacacs          => $_->{tacacs} ? \1 : \0,
+    token_auth_only => $_->{token_auth_only} ? \1 : \0,
+    token_hint      => $_->{token_hint},
+    token_permanent => $_->{token_no_expire} ? \1 : \0,
+    token_allowed_ips => $_->{token_allowed_ips} || [],
+    last_on         => $_->{last_on},
+  }} @users;
+
+  return to_json \@result;
+};
+
+swagger_path {
+  tags => ['User'],
   path => (setting('api_base') || '').'/user',
   description => 'Provision a service account and issue an API token. Creates the user if not present (null password, token-auth only). Idempotent.',
   parameters => [

--- a/lib/App/Netdisco/Web/API/User.pm
+++ b/lib/App/Netdisco/Web/API/User.pm
@@ -1,0 +1,85 @@
+package App::Netdisco::Web::API::User;
+
+use Dancer ':syntax';
+use Dancer::Plugin::DBIC;
+use Dancer::Plugin::Swagger;
+use Dancer::Plugin::Auth::Extensible;
+
+use Try::Tiny;
+
+swagger_path {
+  tags => ['User'],
+  path => (setting('api_base') || '').'/user',
+  description => 'Provision a service account and issue an API token. Creates the user if not present (null password, token-auth only). Idempotent.',
+  parameters => [
+    body => {
+      in => 'body',
+      schema => {
+        type => 'object',
+        required => ['username'],
+        properties => {
+          username => {
+            type => 'string',
+            description => 'Username of the service account',
+          },
+          permanent => {
+            type => 'boolean',
+            default => 0,
+            description => 'Issue a non-expiring token (requires allow_permanent_tokens in config)',
+          },
+          allowed_ips => {
+            type => 'array',
+            items => { type => 'string' },
+            description => 'CIDR prefixes allowed to use this token (omit for no restriction)',
+          },
+          revoke => {
+            type => 'boolean',
+            default => 0,
+            description => 'Revoke the token instead of issuing one',
+          },
+        },
+      },
+    },
+  ],
+  responses => { default => { examples => {
+    'application/json' => { username => 'grafana-svc', api_key => 'cc9d5c02d8898e5728b7d7a0339c0785', permanent => 1 },
+  } } },
+}, post '/api/v1/user' => require_role api_admin => sub {
+  header('Content-Type' => 'application/json');
+
+  my $body = try { from_json(request->body) } catch { {} };
+  my $username = $body->{username}
+    or return send_error(to_json({ error => 'Missing username' }), 400);
+
+  my $user = schema('netdisco')->resultset('User')
+    ->find_or_create({ username => $username });
+
+  if ($body->{revoke}) {
+    $user->update({ token => undef, token_from => undef, token_no_expire => \"false",
+                    token_allowed_ips => undef });
+    return to_json { username => $username, revoked => \1 };
+  }
+
+  my $provider = Dancer::Plugin::Auth::Extensible::auth_provider('users');
+
+  my $want_permanent = $body->{permanent} && setting('allow_permanent_tokens');
+  my $allowed_ips    = (ref $body->{allowed_ips} eq ref []) ? $body->{allowed_ips} : undef;
+
+  $user->update({
+    token_from      => time,
+    token_no_expire => ($want_permanent ? \"true" : \"false"),
+    (defined $allowed_ips ? (token_allowed_ips => $allowed_ips) : ()),
+    ($provider->validate_api_token($user->token)
+      ? () : (token => \'md5(random()::text)')),
+  })->discard_changes();
+
+  return to_json {
+    username  => $username,
+    api_key   => $user->token,
+    permanent => ($user->token_no_expire ? \1 : \0),
+    ($user->token_allowed_ips
+      ? (allowed_ips => $user->token_allowed_ips) : ()),
+  };
+};
+
+true;

--- a/lib/App/Netdisco/Web/Auth/Provider/DBIC.pm
+++ b/lib/App/Netdisco/Web/Auth/Provider/DBIC.pm
@@ -18,6 +18,7 @@ use Authen::TacacsPlus;
 use Path::Class;
 use File::ShareDir 'dist_dir';
 use Try::Tiny;
+use NetAddr::IP::Lite ':lower';
 
 sub authenticate_user {
     my ($self, $username, $password) = @_;
@@ -75,11 +76,18 @@ sub validate_api_token {
       $database->resultset($users_table)->find({ $token_column => $token });
     };
 
-    return $user
-      if $user and $user->in_storage and $user->token_from
-        and ($user->token_no_expire
-          or $user->token_from > (time - setting('api_token_lifetime')));
-    return undef;
+    return undef unless $user and $user->in_storage and $user->token_from
+      and ($user->token_no_expire
+        or $user->token_from > (time - setting('api_token_lifetime')));
+
+    if ($user->token_allowed_ips and scalar @{$user->token_allowed_ips}) {
+      my $client = NetAddr::IP::Lite->new(request->remote_address);
+      return undef unless $client
+        and grep { $client->within(NetAddr::IP::Lite->new($_)) }
+                 @{$user->token_allowed_ips};
+    }
+
+    return $user;
 }
 
 sub get_user_roles {

--- a/lib/App/Netdisco/Web/Auth/Provider/DBIC.pm
+++ b/lib/App/Netdisco/Web/Auth/Provider/DBIC.pm
@@ -70,14 +70,15 @@ sub validate_api_token {
     my $users_table  = $settings->{users_resultset}    || 'User';
     my $token_column = $settings->{users_token_column} || 'token';
 
-    $token =~ s/^Apikey //i; # should be there but swagger-ui doesn't add it
+    $token =~ s/^(?:Apikey|Bearer) //i; # swagger-ui omits scheme; also accept Bearer
     my $user = try {
       $database->resultset($users_table)->find({ $token_column => $token });
     };
 
     return $user
       if $user and $user->in_storage and $user->token_from
-        and $user->token_from > (time - setting('api_token_lifetime'));
+        and ($user->token_no_expire
+          or $user->token_from > (time - setting('api_token_lifetime')));
     return undef;
 }
 

--- a/lib/App/Netdisco/Web/AuthN.pm
+++ b/lib/App/Netdisco/Web/AuthN.pm
@@ -88,7 +88,7 @@ hook 'before' => sub {
 
         my $token = request->header('Authorization');
         my $user = $provider->validate_api_token($token)
-          or return;
+          or return send_error('{"error":"invalid or expired token"}', 401);
 
         session(logged_in_user => $user->username);
         session(logged_in_user_realm => 'users');

--- a/lib/App/Netdisco/Web/AuthN.pm
+++ b/lib/App/Netdisco/Web/AuthN.pm
@@ -8,6 +8,7 @@ use Dancer::Plugin::Swagger;
 use App::Netdisco; # a safe noop but needed for standalone testing
 use App::Netdisco::Util::Web 'request_is_api';
 use MIME::Base64;
+use Try::Tiny;
 use URI::Based;
 
 # ensure that regardless of where the user is redirected, we have a link
@@ -17,7 +18,7 @@ hook 'before' => sub {
       ? request->uri : uri_for(setting('web_home'))->path);
 };
 
-# try to find a valid username according to headers
+# try to find a valid username according to headers
 # or configuration settings
 sub _get_delegated_authn_user {
   my $username = undef;
@@ -34,7 +35,7 @@ sub _get_delegated_authn_user {
 
       ($username = $ENV{REMOTE_USER}) =~ s/@[^@]*$//;
   }
-  # this works for API calls, too
+  # this works for API calls, too
   elsif (setting('no_auth')) {
       $username = 'guest';
   }
@@ -44,7 +45,7 @@ sub _get_delegated_authn_user {
   # from the internals of Dancer::Plugin::Auth::Extensible
   my $provider = Dancer::Plugin::Auth::Extensible::auth_provider('users');
 
-  # may synthesize a user if validate_remote_user=false
+  # may synthesize a user if validate_remote_user=false
   return $provider->get_user_details($username);
 }
 
@@ -74,7 +75,7 @@ hook 'before' => sub {
 
     # this ordering allows override of delegated authN if given creds
 
-    # protect against delegated authN config but no valid user
+    # protect against delegated authN config but no valid user
     if ((not $delegated) and
       (setting('trust_x_remote_user') or setting('trust_remote_user'))) {
         session->destroy;
@@ -129,11 +130,11 @@ post '/login' => sub {
     # validate authN
     my ($success, $realm) = authenticate_user(param('username'),param('password'));
 
-    # or try to get user from somewhere else
+    # or try to get user from somewhere else
     my $delegated = _get_delegated_authn_user();
 
     if (($success and not
-          # protect against delegated authN config but no valid user (then must ignore params)
+          # protect against delegated authN config but no valid user (then must ignore params)
           (not $delegated and (setting('trust_x_remote_user') or setting('trust_remote_user'))))
         or $delegated) {
 
@@ -156,13 +157,25 @@ post '/login' => sub {
         if ($api) {
             header('Content-Type' => 'application/json');
 
-            # if there's a current valid token then reissue it and reset timer
+            my $body = try { from_json(request->body) } catch { {} };
+            my $want_permanent = $body->{permanent} && setting('allow_permanent_tokens');
+            my $allowed_ips    = (ref $body->{allowed_ips} eq ref [])
+                                   ? $body->{allowed_ips} : undef;
+
             $user->update({
-              token_from => time,
+              token_from      => time,
+              token_no_expire => ($want_permanent ? \"true" : \"false"),
+              ($allowed_ips ? (token_allowed_ips => $allowed_ips) : ()),
               ($provider->validate_api_token($user->token)
                 ? () : (token => \'md5(random()::text)')),
             })->discard_changes();
-            return to_json { api_key => $user->token };
+
+            return to_json {
+              api_key   => $user->token,
+              permanent => ($user->token_no_expire ? \1 : \0),
+              ($user->token_allowed_ips
+                ? (allowed_ips => $user->token_allowed_ips) : ()),
+            };
         }
 
         redirect ((scalar URI::Based->new(param('return_url'))->path_query) || '/');

--- a/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
+++ b/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
@@ -80,7 +80,7 @@ ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') =
       $token = _provision_token($user) if param('auth_method') eq 'token';
     });
 
-    return to_json { api_key => $token } if $token;
+    return "<span data-nd-api-key=\"$token\"></span>" if $token;
 };
 
 ajax '/ajax/control/admin/users/del' => require_role setting('defanged_admin') => sub {
@@ -133,7 +133,7 @@ ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin'
       $token = _provision_token($user) if param('auth_method') eq 'token';
     });
 
-    return to_json { api_key => $token } if $token;
+    return "<span data-nd-api-key=\"$token\"></span>" if $token;
 };
 
 get '/ajax/content/admin/users' => require_role admin => sub {

--- a/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
+++ b/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
@@ -33,22 +33,19 @@ sub _make_password {
   }
 }
 
-sub _provision_token {
-  my $user = shift;
-  my $provider = Dancer::Plugin::Auth::Extensible::auth_provider('users');
-  unless ($provider->validate_api_token($user->token)) {
-    $user->update({ token => \'md5(random()::text)', token_from => time });
-    $user->discard_changes();
-  }
-  return $user->token;
+sub _parse_ips {
+  my @ips = grep { length $_ }
+              map { (my $s = $_) =~ s/^\s+|\s+$//g; $s }
+              split(/,/, param('token_allowed_ips') || '');
+  return @ips ? \@ips : undef;
 }
+
 
 ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') => sub {
     send_error('Bad Request', 400) unless _sanity_ok();
 
-    my $token;
     schema(vars->{'tenant'})->txn_do(sub {
-      my $user = schema(vars->{'tenant'})->resultset('User')
+      schema(vars->{'tenant'})->resultset('User')
         ->create({
           username => param('username'),
           fullname => param('fullname'),
@@ -56,8 +53,12 @@ ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') =
           (param('auth_method') eq 'token' ? (
             password => undef,
             ldap => \'false', radius => \'false', tacacs => \'false',
+            token_auth_only => \'true',
+            token_allowed_ips => _parse_ips(),
           ) : (
             password => _make_password(param('password')),
+            token_auth_only => \'false',
+            token_allowed_ips => undef,
             (param('auth_method') ? (
               (ldap => (param('auth_method') eq 'ldap' ? \'true' : \'false')),
               (radius => (param('auth_method') eq 'radius' ? \'true' : \'false')),
@@ -77,10 +78,8 @@ ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') =
           admin => (param('admin') ? \'true' : \'false'),
           note => param('note'),
         });
-      $token = _provision_token($user) if param('auth_method') eq 'token';
     });
-
-    return "<span data-nd-api-key=\"$token\"></span>" if $token;
+    return '';
 };
 
 ajax '/ajax/control/admin/users/del' => require_role setting('defanged_admin') => sub {
@@ -95,7 +94,6 @@ ajax '/ajax/control/admin/users/del' => require_role setting('defanged_admin') =
 ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin') => sub {
     send_error('Bad Request', 400) unless _sanity_ok();
 
-    my $token;
     schema(vars->{'tenant'})->txn_do(sub {
       my $user = schema(vars->{'tenant'})->resultset('User')
         ->find({username => param('username')});
@@ -107,7 +105,11 @@ ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin'
         (param('auth_method') eq 'token' ? (
           password => undef,
           ldap => \'false', radius => \'false', tacacs => \'false',
+          token_auth_only => \'true',
+          token_allowed_ips => _parse_ips(),
         ) : (
+          token_auth_only => \'false',
+          token_allowed_ips => undef,
           ((param('password') and param('password') ne '********')
             ? (password => _make_password(param('password')))
             : ()),
@@ -130,18 +132,35 @@ ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin'
         admin => (param('admin') ? \'true' : \'false'),
         note => param('note'),
       });
-      $token = _provision_token($user) if param('auth_method') eq 'token';
     });
+    return '';
+};
 
-    return "<span data-nd-api-key=\"$token\"></span>" if $token;
+ajax '/ajax/control/admin/users/token' => require_role setting('defanged_admin') => sub {
+  send_error('Bad Request', 400) unless _sanity_ok();
+
+  my $user = schema(vars->{'tenant'})->resultset('User')
+    ->find({ username => param('username') });
+  send_error('Not Found', 404) unless $user and $user->in_storage;
+
+  my $token;
+  schema(vars->{'tenant'})->txn_do(sub {
+    $user->update({ token => \'md5(random()::text)', token_from => time });
+    $user->discard_changes();
+    $token = $user->token;
+  });
+
+  header('Content-Type' => 'text/plain');
+  return $token;
 };
 
 get '/ajax/content/admin/users' => require_role admin => sub {
     my @results = schema(vars->{'tenant'})->resultset('User')
       ->search(undef, {
         '+columns' => {
-          created   => \"to_char(creation, 'YYYY-MM-DD HH24:MI')",
-          last_seen => \"to_char(last_on,  'YYYY-MM-DD HH24:MI')",
+          created    => \"to_char(creation, 'YYYY-MM-DD HH24:MI')",
+          last_seen  => \"to_char(last_on,  'YYYY-MM-DD HH24:MI')",
+          token_hint => \"right(token, 8)",
         },
         order_by => [qw/fullname username/]
       })->hri->all;

--- a/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
+++ b/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
@@ -33,9 +33,20 @@ sub _make_password {
   }
 }
 
+sub _provision_token {
+  my $user = shift;
+  my $provider = Dancer::Plugin::Auth::Extensible::auth_provider('users');
+  unless ($provider->validate_api_token($user->token)) {
+    $user->update({ token => \'md5(random()::text)', token_from => time });
+    $user->discard_changes();
+  }
+  return $user->token;
+}
+
 ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') => sub {
     send_error('Bad Request', 400) unless _sanity_ok();
 
+    my $token;
     schema(vars->{'tenant'})->txn_do(sub {
       my $user = schema(vars->{'tenant'})->resultset('User')
         ->create({
@@ -66,7 +77,10 @@ ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') =
           admin => (param('admin') ? \'true' : \'false'),
           note => param('note'),
         });
+      $token = _provision_token($user) if param('auth_method') eq 'token';
     });
+
+    return to_json { api_key => $token } if $token;
 };
 
 ajax '/ajax/control/admin/users/del' => require_role setting('defanged_admin') => sub {
@@ -81,6 +95,7 @@ ajax '/ajax/control/admin/users/del' => require_role setting('defanged_admin') =
 ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin') => sub {
     send_error('Bad Request', 400) unless _sanity_ok();
 
+    my $token;
     schema(vars->{'tenant'})->txn_do(sub {
       my $user = schema(vars->{'tenant'})->resultset('User')
         ->find({username => param('username')});
@@ -115,7 +130,10 @@ ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin'
         admin => (param('admin') ? \'true' : \'false'),
         note => param('note'),
       });
+      $token = _provision_token($user) if param('auth_method') eq 'token';
     });
+
+    return to_json { api_key => $token } if $token;
 };
 
 get '/ajax/content/admin/users' => require_role admin => sub {

--- a/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
+++ b/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
@@ -40,17 +40,22 @@ ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') =
       my $user = schema(vars->{'tenant'})->resultset('User')
         ->create({
           username => param('username'),
-          password => _make_password(param('password')),
           fullname => param('fullname'),
 
-          (param('auth_method') ? (
-            (ldap => (param('auth_method') eq 'ldap' ? \'true' : \'false')),
-            (radius => (param('auth_method') eq 'radius' ? \'true' : \'false')),
-            (tacacs => (param('auth_method') eq 'tacacs' ? \'true' : \'false')),
+          (param('auth_method') eq 'token' ? (
+            password => undef,
+            ldap => \'false', radius => \'false', tacacs => \'false',
           ) : (
-            ldap => \'false',
-            radius => \'false',
-            tacacs => \'false',
+            password => _make_password(param('password')),
+            (param('auth_method') ? (
+              (ldap => (param('auth_method') eq 'ldap' ? \'true' : \'false')),
+              (radius => (param('auth_method') eq 'radius' ? \'true' : \'false')),
+              (tacacs => (param('auth_method') eq 'tacacs' ? \'true' : \'false')),
+            ) : (
+              ldap => \'false',
+              radius => \'false',
+              tacacs => \'false',
+            )),
           )),
 
           port_control => (param('port_control') ? \'true' : \'false'),
@@ -82,19 +87,24 @@ ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin'
       return unless $user;
 
       $user->update({
-        ((param('password') ne '********')
-          ? (password => _make_password(param('password')))
-          : ()),
         fullname => param('fullname'),
 
-        (param('auth_method') ? (
-          (ldap => (param('auth_method') eq 'ldap' ? \'true' : \'false')),
-          (radius => (param('auth_method') eq 'radius' ? \'true' : \'false')),
-          (tacacs => (param('auth_method') eq 'tacacs' ? \'true' : \'false')),
+        (param('auth_method') eq 'token' ? (
+          password => undef,
+          ldap => \'false', radius => \'false', tacacs => \'false',
         ) : (
-          ldap => \'false',
-          radius => \'false',
-          tacacs => \'false',
+          ((param('password') and param('password') ne '********')
+            ? (password => _make_password(param('password')))
+            : ()),
+          (param('auth_method') ? (
+            (ldap => (param('auth_method') eq 'ldap' ? \'true' : \'false')),
+            (radius => (param('auth_method') eq 'radius' ? \'true' : \'false')),
+            (tacacs => (param('auth_method') eq 'tacacs' ? \'true' : \'false')),
+          ) : (
+            ldap => \'false',
+            radius => \'false',
+            tacacs => \'false',
+          )),
         )),
 
         port_control => (param('port_control') ? \'true' : \'false'),

--- a/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
+++ b/lib/App/Netdisco/Web/Plugin/AdminTask/Users.pm
@@ -50,14 +50,16 @@ ajax '/ajax/control/admin/users/add' => require_role setting('defanged_admin') =
           username => param('username'),
           fullname => param('fullname'),
 
-          (param('auth_method') eq 'token' ? (
+          (param('auth_method') eq 'permanent_token' ? (
             password => undef,
             ldap => \'false', radius => \'false', tacacs => \'false',
-            token_auth_only => \'true',
+            token_auth_only  => \'true',
+            token_no_expire  => \"true",
             token_allowed_ips => _parse_ips(),
           ) : (
             password => _make_password(param('password')),
             token_auth_only => \'false',
+            token_no_expire => \"false",
             token_allowed_ips => undef,
             (param('auth_method') ? (
               (ldap => (param('auth_method') eq 'ldap' ? \'true' : \'false')),
@@ -102,13 +104,15 @@ ajax '/ajax/control/admin/users/update' => require_role setting('defanged_admin'
       $user->update({
         fullname => param('fullname'),
 
-        (param('auth_method') eq 'token' ? (
+        ((param('auth_method') eq 'token' or param('auth_method') eq 'permanent_token') ? (
           password => undef,
           ldap => \'false', radius => \'false', tacacs => \'false',
-          token_auth_only => \'true',
+          token_auth_only  => \'true',
+          token_no_expire  => (param('auth_method') eq 'permanent_token' ? \"true" : \"false"),
           token_allowed_ips => _parse_ips(),
         ) : (
           token_auth_only => \'false',
+          token_no_expire => \"false",
           token_allowed_ips => undef,
           ((param('password') and param('password') ne '********')
             ? (password => _make_password(param('password')))

--- a/lib/App/Netdisco/Worker/Plugin/GetAPIKey.pm
+++ b/lib/App/Netdisco/Worker/Plugin/GetAPIKey.pm
@@ -15,7 +15,8 @@ register_worker({ phase => 'check' }, sub {
 
 register_worker({ phase => 'main' }, sub {
   my ($job, $workerconf) = @_;
-  my $username = $job->extra;
+  my $username  = $job->extra;
+  my $flag      = $job->port || '';
 
   my $user = schema('netdisco')->resultset('User')
     ->find({ username => $username });
@@ -23,18 +24,27 @@ register_worker({ phase => 'main' }, sub {
   return Status->error("No such user")
     unless $user and $user->in_storage;
 
+  if ($flag eq 'revoke') {
+    $user->update({ token => undef, token_from => undef, token_no_expire => \"false" });
+    return Status->done(sprintf 'Revoked API token for user %s', $username);
+  }
+
   # from the internals of Dancer::Plugin::Auth::Extensible
   my $provider = Dancer::Plugin::Auth::Extensible::auth_provider('users');
 
-  # if there's a current valid token then reissue it and reset timer
-  $user->update({
-      token_from => time,
-      ($provider->validate_api_token($user->token)
-        ? () : (token => \'md5(random()::text)')),
-    })->discard_changes();
+  my %updates = (
+    token_from     => time,
+    token_no_expire => ($flag eq 'permanent' ? \"true" : \"false"),
+    ($provider->validate_api_token($user->token)
+      ? () : (token => \'md5(random()::text)')),
+  );
+
+  $user->update(\%updates)->discard_changes();
 
   return Status->done(
-    sprintf 'Set token for user %s: %s', $username, $user->token);
+    sprintf 'Set %s token for user %s: %s',
+      ($flag eq 'permanent' ? 'permanent' : 'session'),
+      $username, $user->token);
 });
 
 true;

--- a/lib/App/Netdisco/Worker/Plugin/GetAPIKey.pm
+++ b/lib/App/Netdisco/Worker/Plugin/GetAPIKey.pm
@@ -19,10 +19,7 @@ register_worker({ phase => 'main' }, sub {
   my $flag      = $job->port || '';
 
   my $user = schema('netdisco')->resultset('User')
-    ->find({ username => $username });
-
-  return Status->error("No such user")
-    unless $user and $user->in_storage;
+    ->find_or_create({ username => $username });
 
   if ($flag eq 'revoke') {
     $user->update({ token => undef, token_from => undef, token_no_expire => \"false" });

--- a/share/config.yml
+++ b/share/config.yml
@@ -35,6 +35,7 @@ trust_remote_user: false
 trust_x_remote_user: false
 validate_remote_user: false
 api_token_lifetime: 3600
+allow_permanent_tokens: false
 tacacs: {}
 radius: {}
 ldap: {}

--- a/share/schema_versions/App-Netdisco-DB-96-97-PostgreSQL.sql
+++ b/share/schema_versions/App-Netdisco-DB-96-97-PostgreSQL.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE users ADD COLUMN token_no_expire boolean DEFAULT false;
+
+COMMIT;

--- a/share/schema_versions/App-Netdisco-DB-96-97-PostgreSQL.sql
+++ b/share/schema_versions/App-Netdisco-DB-96-97-PostgreSQL.sql
@@ -2,5 +2,6 @@ BEGIN;
 
 ALTER TABLE users ADD COLUMN token_no_expire boolean DEFAULT false;
 ALTER TABLE users ADD COLUMN token_allowed_ips text[];
+ALTER TABLE users ADD COLUMN token_auth_only boolean DEFAULT false;
 
 COMMIT;

--- a/share/schema_versions/App-Netdisco-DB-96-97-PostgreSQL.sql
+++ b/share/schema_versions/App-Netdisco-DB-96-97-PostgreSQL.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
 ALTER TABLE users ADD COLUMN token_no_expire boolean DEFAULT false;
+ALTER TABLE users ADD COLUMN token_allowed_ips text[];
 
 COMMIT;

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -47,7 +47,7 @@
             <option value="ldap">LDAP</option>
             <option value="radius">RADIUS</option>
             <option value="tacacs">TACACS</option>
-            <option value="token">Token only</option>
+            <option value="permanent_token">Permanent Token</option>
           </select>
         </div>
       </td>
@@ -97,7 +97,7 @@
             <option[% ' selected' IF row.ldap %] value="ldap">LDAP</option>
             <option[% ' selected' IF row.radius %] value="radius">RADIUS</option>
             <option[% ' selected' IF row.tacacs %] value="tacacs">TACACS</option>
-            <option[% ' selected' IF row.token_auth_only %] value="token">Token only</option>
+            <option[% ' selected' IF row.token_auth_only %] value="permanent_token">Permanent Token</option>
           </select>
         </div>
       </td>
@@ -181,7 +181,7 @@ $(document).ready(function() {
     var pw   = row.find('.nd_pw_field');
     var hint = row.find('.nd_token_hint');
     var ips  = row.find('.nd_allowed_ips_field');
-    if ($(select).val() === 'token') {
+    if ($(select).val() === 'permanent_token') {
       pw.hide().val('').prop('disabled', true);
       hint.show();
       ips.prop('disabled', false);
@@ -212,8 +212,8 @@ $(document).ready(function() {
   };
 
   $(document).on('click', '.nd_tokenbutton', function() {
-    var username = $(this).data('username');
-    $.get(uri_base + '/ajax/control/admin/users/token', { username: username }, function(apiKey) {
+    var username  = $(this).data('username');
+    $.get(uri_base + '/ajax/control/admin/users/token', { username: username, permanent: 1 }, function(apiKey) {
       apiKey = $.trim(apiKey);
       if (apiKey && typeof window.nd_show_api_token === 'function') {
         window.nd_show_api_token(apiKey);

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -17,14 +17,15 @@
     <tr>
       <td class="nd_center-cell"><input data-form="add" name="fullname" type="text"></td>
       <td class="nd_center-cell"><input class="span2" data-form="add" name="username" type="text"></td>
-      <td class="nd_center-cell"><input class="span1" data-form="add" name="password" type="password"></td>
+      <td class="nd_center-cell"><input class="span1 nd_pw_field" data-form="add" name="password" type="password"></td>
       <td class="nd_center-cell">
         <div class="form-group">
-          <select class="span2 form-control" data-form="add" name="auth_method">
+          <select class="span2 form-control nd_auth_method" data-form="add" name="auth_method">
             <option value="" selected>Netdisco Password</option>
             <option value="ldap">LDAP</option>
             <option value="radius">RADIUS</option>
             <option value="tacacs">TACACS</option>
+            <option value="token">Token only</option>
           </select>
         </div>
       </td>
@@ -59,15 +60,17 @@
         <input class="span2" data-form="update" name="username" type="text" value="[% row.username | html_entity %]">
       </td>
       <td class="nd_center-cell">
-        <input class="span1" data-form="update" name="password" type="password" value="********">
+        <input class="span1 nd_pw_field" data-form="update" name="password" type="password"
+          [%- IF NOT row.ldap AND NOT row.radius AND NOT row.tacacs AND NOT row.password %] disabled placeholder="N/A"[% ELSE %] value="********"[% END %]>
       </td>
       <td class="nd_center-cell">
         <div class="form-group">
-          <select class="span2 form-control" data-form="update" name="auth_method">
-            <option value="">Netdisco Password</option>
+          <select class="span2 form-control nd_auth_method" data-form="update" name="auth_method">
+            <option[% ' selected' IF NOT row.ldap AND NOT row.radius AND NOT row.tacacs AND row.password %] value="">Netdisco Password</option>
             <option[% ' selected' IF row.ldap %] value="ldap">LDAP</option>
             <option[% ' selected' IF row.radius %] value="radius">RADIUS</option>
             <option[% ' selected' IF row.tacacs %] value="tacacs">TACACS</option>
+            <option[% ' selected' IF NOT row.ldap AND NOT row.radius AND NOT row.tacacs AND NOT row.password %] value="token">Token only</option>
           </select>
         </div>
       </td>
@@ -122,6 +125,17 @@
 
 <script>
 $(document).ready(function() {
+  function togglePasswordField(select) {
+    var pw = $(select).closest('tr').find('.nd_pw_field');
+    if ($(select).val() === 'token') {
+      pw.val('').prop('disabled', true).attr('placeholder', 'N/A');
+    } else {
+      pw.prop('disabled', false).attr('placeholder', '');
+    }
+  }
+  $('.nd_auth_method').each(function() { togglePasswordField(this); });
+  $(document).on('change', '.nd_auth_method', function() { togglePasswordField(this); });
+
   $('#data-table').dataTable({
     "columnDefs": [ 
       {

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -5,6 +5,7 @@
       <th class="nd_center-cell">Username</th>
       <th class="nd_center-cell">Password</th>
       <th class="nd_center-cell">Auth Method</th>
+      <th class="nd_center-cell">Allowed IPs</th>
       <th class="nd_center-cell">Port Control</th>
       <th class="nd_center-cell">Administrator</th>
       <th class="nd_center-cell">Created</th>
@@ -30,6 +31,9 @@
         </div>
       </td>
       <td class="nd_center-cell">
+        <input class="span2 nd_allowed_ips_field" data-form="add" name="token_allowed_ips" type="text" placeholder="192.0.2.0/28, 2001:db8::/64" disabled>
+      </td>
+      <td class="nd_center-cell">
         <div class="form-group">
           <select class="span2 form-control" data-form="add" name="port_control">
             <option value="" selected>Off</option>
@@ -52,6 +56,7 @@
     [% SET count = 0 %]
     [% FOREACH row IN results %]
     [% SET count = count + 1 %]
+    [% SET is_token = row.token_auth_only %]
     <tr>
       <td class="nd_center-cell">
         <input data-form="update" name="fullname" type="text" value="[% row.fullname | html_entity %]">
@@ -61,18 +66,24 @@
       </td>
       <td class="nd_center-cell">
         <input class="span1 nd_pw_field" data-form="update" name="password" type="password"
-          [%- IF NOT row.ldap AND NOT row.radius AND NOT row.tacacs AND NOT row.password %] disabled placeholder="N/A"[% ELSE %] value="********"[% END %]>
+          [%- IF is_token %] style="display:none" disabled[% ELSIF row.password %] value="********"[% ELSE %] disabled placeholder="N/A"[% END %]>
+        <small class="nd_token_hint muted"[% IF NOT is_token %] style="display:none"[% END %]>[% IF row.token_hint %]...[% row.token_hint | html_entity %][% ELSE %]no token[% END %]</small>
       </td>
       <td class="nd_center-cell">
         <div class="form-group">
           <select class="span2 form-control nd_auth_method" data-form="update" name="auth_method">
-            <option[% ' selected' IF NOT row.ldap AND NOT row.radius AND NOT row.tacacs AND row.password %] value="">Netdisco Password</option>
+            <option[% ' selected' IF NOT row.token_auth_only AND NOT row.ldap AND NOT row.radius AND NOT row.tacacs %] value="">Netdisco Password</option>
             <option[% ' selected' IF row.ldap %] value="ldap">LDAP</option>
             <option[% ' selected' IF row.radius %] value="radius">RADIUS</option>
             <option[% ' selected' IF row.tacacs %] value="tacacs">TACACS</option>
-            <option[% ' selected' IF NOT row.ldap AND NOT row.radius AND NOT row.tacacs AND NOT row.password %] value="token">Token only</option>
+            <option[% ' selected' IF row.token_auth_only %] value="token">Token only</option>
           </select>
         </div>
+      </td>
+      <td class="nd_center-cell">
+        <input class="span2 nd_allowed_ips_field" data-form="update" name="token_allowed_ips" type="text"
+          value="[% row.token_allowed_ips.join(', ') IF row.token_allowed_ips %]"
+          [% IF NOT is_token %]disabled[% END %] placeholder="192.0.2.0/28, 2001:db8::/64">
       </td>
       <td class="nd_center-cell">
         <div class="form-group">
@@ -96,6 +107,8 @@
 
       <td nowrap class="nd_center-cell">
         <button class="btn nd_adminbutton" name="update" type="submit"><i class="icon-save text-warning"></i></button>
+
+        [% IF is_token %]<button class="btn nd_tokenbutton" data-username="[% row.username | html_entity %]" type="button" title="Generate new API token"><i class="icon-key"></i></button>[% END %]
 
         <button class="btn" data-toggle="modal"
           data-target="#nd_devdel-[% count | html_entity %]" type="button"><i class="icon-trash text-error"></i></button>
@@ -129,7 +142,7 @@
     <h3>API Token</h3>
   </div>
   <div class="modal-body">
-    <p class="text-info">Copy this token — it will not be shown again unless you re-save with Token only selected.</p>
+    <p class="text-info">Copy this token — it will not be shown again.</p>
     <div class="input-append">
       <input id="nd_token-value" type="text" class="span4" readonly>
       <button class="btn" id="nd_token-copy" type="button"><i class="icon-copy"></i> Copy</button>
@@ -142,16 +155,23 @@
 
 <script>
 $(document).ready(function() {
-  function togglePasswordField(select) {
-    var pw = $(select).closest('tr').find('.nd_pw_field');
+  function toggleTokenFields(select) {
+    var row  = $(select).closest('tr');
+    var pw   = row.find('.nd_pw_field');
+    var hint = row.find('.nd_token_hint');
+    var ips  = row.find('.nd_allowed_ips_field');
     if ($(select).val() === 'token') {
-      pw.val('').prop('disabled', true).attr('placeholder', 'N/A');
+      pw.hide().val('').prop('disabled', true);
+      hint.show();
+      ips.prop('disabled', false);
     } else {
-      pw.prop('disabled', false).attr('placeholder', '');
+      pw.show().prop('disabled', false).attr('placeholder', '');
+      hint.hide();
+      ips.val('').prop('disabled', true);
     }
   }
-  $('.nd_auth_method').each(function() { togglePasswordField(this); });
-  $(document).on('change', '.nd_auth_method', function() { togglePasswordField(this); });
+  $('.nd_auth_method').each(function() { toggleTokenFields(this); });
+  $(document).on('change', '.nd_auth_method', function() { toggleTokenFields(this); });
 
   $('#nd_token-reveal').modal({show: false});
   $('#nd_token-copy').on('click', function() {
@@ -163,17 +183,35 @@ $(document).ready(function() {
   window.nd_show_api_token = function(apiKey) {
     $('#nd_token-value').val(apiKey);
     $('#nd_token-copy').html('<i class="icon-copy"></i> Copy');
+    $('#nd_token-reveal').one('hidden', function() {
+      var tab = '[% task.tag | html_entity %]';
+      $('#' + tab + '_form').trigger('submit');
+    });
     $('#nd_token-reveal').modal('show');
   };
 
+  $(document).on('click', '.nd_tokenbutton', function() {
+    var username = $(this).data('username');
+    $.get(uri_base + '/ajax/control/admin/users/token', { username: username }, function(apiKey) {
+      apiKey = $.trim(apiKey);
+      if (apiKey && typeof window.nd_show_api_token === 'function') {
+        window.nd_show_api_token(apiKey);
+      } else {
+        toastr.error('Could not retrieve token');
+      }
+    }, 'text').fail(function() {
+      toastr.error('Could not retrieve token');
+    });
+  });
+
   $('#data-table').dataTable({
-    "columnDefs": [ 
+    "columnDefs": [
       {
-        "targets": [ 2, 3, 4, 5, 6, 7, 8, 9 ],
+        "targets": [ 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
         "searchable": false
       },
       {
-        "targets": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ],
+        "targets": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
         "orderable": false
       }
     ],

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -3,19 +3,19 @@
 [%- SET has_tacacs = settings.tacacs AND settings.tacacs.size       > 0 -%]
 
 <dl class="dl-horizontal" style="font-size:12px;margin-bottom:1em">
-  <dt class="muted">Backends</dt>
+  <dt class="muted" title="ldap / radius / tacacs">Backends</dt>
   <dd>[% IF has_ldap %]LDAP [% END %][% IF has_radius %]RADIUS [% END %][% IF has_tacacs %]TACACS[% END %][% IF NOT (has_ldap OR has_radius OR has_tacacs) %]local only[% END %]</dd>
   [% IF settings.no_auth %]
-  <dt class="muted">Auth</dt>
+  <dt class="muted" title="no_auth">Auth</dt>
   <dd><i class="icon-warning-sign text-warning"></i> no_auth — bypassed</dd>
   [% END %]
   [% IF NOT settings.safe_password_store %]
-  <dt class="muted">Passwords</dt>
+  <dt class="muted" title="safe_password_store">Passwords</dt>
   <dd><i class="icon-warning-sign text-error"></i> MD5 — unsafe</dd>
   [% END %]
-  <dt class="muted">Session token</dt>
+  <dt class="muted" title="api_token_lifetime">Session token</dt>
   <dd>expires after [% settings.api_token_lifetime %]s</dd>
-  <dt class="muted">Permanent token</dt>
+  <dt class="muted" title="allow_permanent_tokens">Permanent token</dt>
   <dd>[% IF settings.allow_permanent_tokens %]enabled[% ELSE %]<i class="icon-warning-sign text-warning"></i> disabled[% END %]</dd>
 </dl>
 

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -1,3 +1,24 @@
+[%- SET has_ldap   = settings.ldap   AND settings.ldap.keys.size   > 0 -%]
+[%- SET has_radius = settings.radius AND settings.radius.keys.size > 0 -%]
+[%- SET has_tacacs = settings.tacacs AND settings.tacacs.size       > 0 -%]
+
+<dl class="dl-horizontal" style="font-size:12px;margin-bottom:1em">
+  <dt class="muted">Backends</dt>
+  <dd>[% IF has_ldap %]LDAP [% END %][% IF has_radius %]RADIUS [% END %][% IF has_tacacs %]TACACS[% END %][% IF NOT (has_ldap OR has_radius OR has_tacacs) %]local only[% END %]</dd>
+  [% IF settings.no_auth %]
+  <dt class="muted">Auth</dt>
+  <dd><i class="icon-warning-sign text-warning"></i> no_auth — bypassed</dd>
+  [% END %]
+  [% IF NOT settings.safe_password_store %]
+  <dt class="muted">Passwords</dt>
+  <dd><i class="icon-warning-sign text-error"></i> MD5 — unsafe</dd>
+  [% END %]
+  <dt class="muted">Session token</dt>
+  <dd>expires after [% settings.api_token_lifetime %]s</dd>
+  <dt class="muted">Permanent token</dt>
+  <dd>[% IF settings.allow_permanent_tokens %]enabled[% ELSE %]<i class="icon-warning-sign text-warning"></i> disabled[% END %]</dd>
+</dl>
+
 <table id="data-table" class="table table-striped table-bordered" width="100%" cellspacing="0">
   <thead>
     <tr>

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -123,6 +123,23 @@
   </tbody>
 </table>
 
+<div id="nd_token-reveal" class="nd_modal nd_deep-horizon modal hide fade" tabindex="-1" role="dialog">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal">x</button>
+    <h3>API Token</h3>
+  </div>
+  <div class="modal-body">
+    <p class="text-info">Copy this token — it will not be shown again unless you re-save with Token only selected.</p>
+    <div class="input-append">
+      <input id="nd_token-value" type="text" class="span4" readonly>
+      <button class="btn" id="nd_token-copy" type="button"><i class="icon-copy"></i> Copy</button>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-success" data-dismiss="modal">Done</button>
+  </div>
+</div>
+
 <script>
 $(document).ready(function() {
   function togglePasswordField(select) {
@@ -135,6 +152,49 @@ $(document).ready(function() {
   }
   $('.nd_auth_method').each(function() { togglePasswordField(this); });
   $(document).on('change', '.nd_auth_method', function() { togglePasswordField(this); });
+
+  $('#nd_token-reveal').modal({show: false});
+  $('#nd_token-copy').on('click', function() {
+    navigator.clipboard.writeText($('#nd_token-value').val());
+    $(this).html('<i class="icon-ok"></i> Copied');
+  });
+
+  // Intercept add/update for Token only rows — fires before the generic
+  // admintask.js handler because we bind on a closer ancestor (#data-table)
+  $('#data-table').on('click', '.nd_adminbutton', function(event) {
+    var mode = $(this).attr('name');
+    if (mode === 'del') return;
+    var authMethod = $(this).closest('tr').find('select[name="auth_method"]').val();
+    if (authMethod !== 'token') return;
+
+    event.stopImmediatePropagation();
+    event.preventDefault();
+
+    var task = 'users/';
+    $.ajax({
+      type: 'POST',
+      url: uri_base + '/ajax/control/admin/' + task + mode,
+      data: $(this).closest('tr').find('input[data-form="' + mode + '"],select[data-form="' + mode + '"]').serializeArray(),
+      success: function(data) {
+        try {
+          var json = JSON.parse(data);
+          if (json && json.api_key) {
+            $('#nd_token-value').val(json.api_key);
+            $('#nd_token-copy').html('<i class="icon-copy"></i> Copy');
+            $('#nd_token-reveal').modal('show');
+          } else {
+            toastr.success(mode === 'add' ? 'Added record' : 'Updated record');
+          }
+        } catch(e) {
+          toastr.success(mode === 'add' ? 'Added record' : 'Updated record');
+        }
+        $('#users_form').trigger('submit');
+      },
+      error: function() {
+        toastr.error(mode === 'add' ? 'Failed to add record' : 'Failed to update record');
+      }
+    });
+  });
 
   $('#data-table').dataTable({
     "columnDefs": [ 

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -159,42 +159,12 @@ $(document).ready(function() {
     $(this).html('<i class="icon-ok"></i> Copied');
   });
 
-  // Intercept add/update for Token only rows — fires before the generic
-  // admintask.js handler because we bind on a closer ancestor (#data-table)
-  $('#data-table').on('click', '.nd_adminbutton', function(event) {
-    var mode = $(this).attr('name');
-    if (mode === 'del') return;
-    var authMethod = $(this).closest('tr').find('select[name="auth_method"]').val();
-    if (authMethod !== 'token') return;
-
-    event.stopImmediatePropagation();
-    event.preventDefault();
-
-    var task = 'users/';
-    $.ajax({
-      type: 'POST',
-      url: uri_base + '/ajax/control/admin/' + task + mode,
-      data: $(this).closest('tr').find('input[data-form="' + mode + '"],select[data-form="' + mode + '"]').serializeArray(),
-      success: function(data) {
-        try {
-          var json = JSON.parse(data);
-          if (json && json.api_key) {
-            $('#nd_token-value').val(json.api_key);
-            $('#nd_token-copy').html('<i class="icon-copy"></i> Copy');
-            $('#nd_token-reveal').modal('show');
-          } else {
-            toastr.success(mode === 'add' ? 'Added record' : 'Updated record');
-          }
-        } catch(e) {
-          toastr.success(mode === 'add' ? 'Added record' : 'Updated record');
-        }
-        $('#users_form').trigger('submit');
-      },
-      error: function() {
-        toastr.error(mode === 'add' ? 'Failed to add record' : 'Failed to update record');
-      }
-    });
-  });
+  // Called by admintask.js when the server returns a data-nd-api-key span
+  window.nd_show_api_token = function(apiKey) {
+    $('#nd_token-value').val(apiKey);
+    $('#nd_token-copy').html('<i class="icon-copy"></i> Copy');
+    $('#nd_token-reveal').modal('show');
+  };
 
   $('#data-table').dataTable({
     "columnDefs": [ 

--- a/share/views/ajax/admintask/users.tt
+++ b/share/views/ajax/admintask/users.tt
@@ -83,7 +83,8 @@
         <input data-form="update" name="fullname" type="text" value="[% row.fullname | html_entity %]">
       </td>
       <td class="nd_center-cell">
-        <input class="span2" data-form="update" name="username" type="text" value="[% row.username | html_entity %]">
+        <input data-form="update" name="username" type="hidden" value="[% row.username | html_entity %]">
+        [% row.username | html_entity %]
       </td>
       <td class="nd_center-cell">
         <input class="span1 nd_pw_field" data-form="update" name="password" type="password"

--- a/share/views/js/admintask.js
+++ b/share/views/js/admintask.js
@@ -227,7 +227,13 @@
             );
           }
         }
-        ,success: function() {
+        ,success: function(data) {
+          var apiKey = $(data).filter('[data-nd-api-key]').attr('data-nd-api-key');
+          if (apiKey && typeof window.nd_show_api_token === 'function') {
+            window.nd_show_api_token(apiKey);
+            $('#' + tab + '_form').trigger('submit');
+            return;
+          }
           if (mode == 'add') {
             toastr.success('Added record');
             $('#' + tab + '_form').trigger('submit');


### PR DESCRIPTION
In environments where service accounts need stable, non-expiring API credentials, session tokens (which expire after `api_token_lifetime`) are not suitable. This adds permanent tokens with optional IP restrictions.

- Adds `token_no_expire` boolean and `token_allowed_ips text[]` columns to `users` table (DB migration 96→97)
- Adds `token_auth_only` boolean column — a semantic marker for accounts intended for token-only access (no password). Enforcement is already provided by the null password, but the flag drives the GUI display and is exposed via `GET /api/v1/users` so API consumers can identify service accounts without inspecting password state. Note: `token_auth_only=true` implies `token_no_expire=true` — a passwordless account with a short-lived token would be permanently locked out once it expires. The GUI enforces this by only offering a single "Permanent Token" option.
- Permanent tokens bypass the `api_token_lifetime` expiry check in both `validate_api_token` and the `UserRole` SQL view
- `Authorization: Bearer <token>` is now accepted alongside the existing raw `Authorization: <token>` format — no OAuth machinery, just the standard HTTP scheme. Both styles continue to work.
- Per-user CIDR IP allowlist: if `token_allowed_ips` is set, API token requests from outside the listed prefixes are rejected (applies to token validation only, not web GUI login)
- `getapikey` gains `-p permanent` to create a non-expiring token and `-p revoke` to clear all tokens for a user
- `/login` API endpoint now accepts a JSON body `{"permanent": true, "allowed_ips": ["10.0.0.0/8"]}` and returns `{api_key, permanent, allowed_ips}` — gated by `allow_permanent_tokens: false` config flag
- `POST /api/v1/user` — idempotent service account provisioning: creates user if absent (null password, token-auth only), issues or rotates token, sets permanent flag and IP allowlist
- `GET /api/v1/users` — list all users with roles and token status (hint, permanent flag, allowed IPs)
- GUI service account management: auth method dropdown has a single **Permanent Token** option (sets `token_auth_only` + `token_no_expire`), dedicated token-generate button, allowed IPs field

<img width="1693" height="480" alt="image" src="https://github.com/user-attachments/assets/301270be-cde5-40c4-bb81-4952f2ddd08f" />

## Usage

```bash
# Via netdisco-do (headless/CLI)
~/bin/netdisco-do getapikey -e grafana-user -p permanent

# Via /login API (swagger UI or curl)
curl -X POST /login -u user:pass \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{"permanent": true, "allowed_ips": ["192.168.1.0/24"]}'

# Via REST API (service account provisioning)
curl -X POST /api/v1/user \
  -H 'Authorization: Bearer <admin-token>' \
  -H 'Content-Type: application/json' \
  -d '{"username": "grafana-svc", "permanent": true, "allowed_ips": ["10.0.0.0/8"]}'

# Use the token — both formats accepted
curl /api/v1/... -H 'Authorization: Bearer <token>'
curl /api/v1/... -H 'Authorization: <token>'
```

## Config

```yaml
allow_permanent_tokens: false  # set true to allow permanent tokens
```

## Test plan

- [x] Normal session token still expires after `api_token_lifetime`
- [x] `token_no_expire: true` bypasses expiry in both `validate_api_token` and UserRole SQL
- [x] `Authorization: Bearer <token>` accepted; raw `Authorization: <token>` without prefix also still works
- [x] `token_allowed_ips` rejects requests from outside the listed CIDRs
- [x] Web GUI login not affected by `token_allowed_ips`
- [x] `getapikey -p permanent` sets `token_no_expire = true`; `-p revoke` clears all token fields
- [x] `/login` with `permanent: true` only works when `allow_permanent_tokens: true` in config
- [x] `POST /api/v1/user` creates account and issues token idempotently
- [x] `GET /api/v1/users` returns user list with token hints and flags
- [x] GUI: Permanent Token dropdown sets token_auth_only + token_no_expire; token button always issues permanent token
- [ ] Wiki update