### PR TITLE
Bug/snmp device type undef

### DIFF
--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -220,7 +220,7 @@ sub _snmp_connect_generic {
             ($useclass ? 0 : 1) );
       # if successful, restore the default/user timeouts and return
       if ($info) {
-          my $class = ($useclass ? $classes[0] : $info->device_type);
+          my $class = ($useclass ? $classes[0] : $info->device_type) // $classes[0];
           return $class->new(
             %snmp_args, Version => $ver,
             ($info->offline ? (Cache => $info->cache) : ()),
@@ -246,7 +246,7 @@ sub _snmp_connect_generic {
 
           # if successful, restore the default/user timeouts and return
           if ($info) {
-              my $class = ($useclass ? $classes[0] : $info->device_type);
+              my $class = ($useclass ? $classes[0] : $info->device_type) // $classes[0];
               return $class->new(
                 %snmp_args, Version => $ver,
                 ($info->offline ? (Cache => $info->cache) : ()),
@@ -310,8 +310,8 @@ sub _try_connect {
                                : _try_write($info, $device, $comm));
 
       # first time a device is discovered, re-instantiate into specific class
-      if ($reclass and $info and $info->device_type ne $class) {
-          $class = $info->device_type;
+      if ($reclass and $info and ($info->device_type // '') ne $class) {
+          $class = $info->device_type // $class;
           $info->offline || debug
             sprintf '[%s:%s] try_connect with v: %s, new class: %s, comm: %s',
               $snmp_args->{DestHost}, $snmp_args->{RemotePort},

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -221,6 +221,7 @@ sub _snmp_connect_generic {
       # if successful, restore the default/user timeouts and return
       if ($info) {
           my $class = ($useclass ? $classes[0] : $info->device_type) // $classes[0];
+          Module::Load::load $class;
           return $class->new(
             %snmp_args, Version => $ver,
             ($info->offline ? (Cache => $info->cache) : ()),
@@ -247,6 +248,7 @@ sub _snmp_connect_generic {
           # if successful, restore the default/user timeouts and return
           if ($info) {
               my $class = ($useclass ? $classes[0] : $info->device_type) // $classes[0];
+              Module::Load::load $class;
               return $class->new(
                 %snmp_args, Version => $ver,
                 ($info->offline ? (Cache => $info->cache) : ()),


### PR DESCRIPTION
`device_type()` can return undef when SNMP connects successfully but class resolution fails (e.g. unknown device on first discovery). Calling `->new` on undef causes a fatal crash. Fall back to the base class in all affected spots.

Also fixes the companion case where the resolved class module is not loaded before `->new` is called, causing a similar fatal crash.

These bugs were discovered via the improved SNMP exception reporting in #1564 — without readable error messages they appeared as a generic `exception in SNMP - could be job timeout or crash` with no indication of the root cause.

**Before**:
```
exception in SNMP - could be job timeout or crash: Can't call method "new" on an undefined value at .../Transport/SNMP.pm line 251
exception in SNMP - could be job timeout or crash: Can't locate object method "new" via package "SNMP::Info::Layer3::C6500"
```

**After:**
```
discover: successful
```

## Test plan
- [x] Discover a device seen for the first time where `device_type()` would return undef — confirm no crash
- [x] Discover a device whose resolved SNMP class is not pre-loaded — confirm no crash
- [x] Confirm normal re-discovery of known devices is unaffected