### PR TITLE
Add GET /api/v1/queue/status endpoint

### DIFF
--- a/lib/App/Netdisco/Web/API/Queue.pm
+++ b/lib/App/Netdisco/Web/API/Queue.pm
@@ -39,10 +39,10 @@ swagger_path {
     ? { finished => { '>=' => \["to_timestamp(?)", $since_epoch] } }
     : {};
 
-  my $queued  = try { $rs->search({ status => 'queued'  })->count } // 0;
-  my $running = try { $rs->search({ status => 'running' })->count } // 0;
-  my $done    = try { $rs->search({ status => 'done',  %$since_filter })->count } // 0;
-  my $failed  = try { $rs->search({ status => 'error', %$since_filter })->count } // 0;
+  my $queued  = try { $rs->search({ status => 'queued'  })->count } catch { 0 };
+  my $running = try { $rs->search({ status => 'running' })->count } catch { 0 };
+  my $done    = try { $rs->search({ status => 'done',  %$since_filter })->count } catch { 0 };
+  my $failed  = try { $rs->search({ status => 'error', %$since_filter })->count } catch { 0 };
 
   return to_json {
     queued  => $queued,

--- a/lib/App/Netdisco/Web/API/Queue.pm
+++ b/lib/App/Netdisco/Web/API/Queue.pm
@@ -10,6 +10,51 @@ use Try::Tiny;
 
 swagger_path {
   tags => ['Queue'],
+  path => (setting('api_base') || '').'/queue/status',
+  description => 'Return counts of jobs by status. queued/running reflect current state; done/failed are optionally scoped by since.',
+  parameters => [
+    since => {
+      in => 'query',
+      description => 'Limit done/failed counts to jobs finished within this duration. Examples: 1h, 30m, 2d. Default: all time.',
+      required => 0,
+    },
+  ],
+  responses => { default => {} },
+}, get '/api/v1/queue/status' => require_role api_admin => sub {
+  my $since = params->{since} || '';
+
+  my $since_epoch = undef;
+  if ($since =~ /^(\d+)(m|h|d)$/) {
+    my ($n, $unit) = ($1, $2);
+    my %mul = (m => 60, h => 3600, d => 86400);
+    $since_epoch = time - ($n * $mul{$unit});
+  }
+  elsif ($since) {
+    send_error('Invalid since format. Use e.g. 30m, 2h, 7d', 400);
+  }
+
+  my $rs = schema(vars->{'tenant'})->resultset('Admin');
+
+  my $since_filter = $since_epoch
+    ? { finished => { '>=' => \["to_timestamp(?)", $since_epoch] } }
+    : {};
+
+  my $queued  = try { $rs->search({ status => 'queued'  })->count } // 0;
+  my $running = try { $rs->search({ status => 'running' })->count } // 0;
+  my $done    = try { $rs->search({ status => 'done',  %$since_filter })->count } // 0;
+  my $failed  = try { $rs->search({ status => 'error', %$since_filter })->count } // 0;
+
+  return to_json {
+    queued  => $queued,
+    running => $running,
+    done    => $done,
+    failed  => $failed,
+    since   => ($since || 'all time'),
+  };
+};
+
+swagger_path {
+  tags => ['Queue'],
   path => (setting('api_base') || '').'/queue/backends',
   description => 'Return list of currently active backend names (usually FQDN)',
   responses => { default => {} },


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/queue/status` endpoint returning live job counts by status
- `queued` and `running` always reflect the current state
- `done` and `failed` support an optional `?since=` filter (e.g. `30m`, `2h`, `7d`) to limit counts to jobs finished within that window
- Useful for automation (or monitoring) to avoid over-submitting jobs — callers can check the current queue depth before enqueuing more work, which helps limit backpressure when bulk-adding tasks (e.g. nightly discoverall runs)
- Complements the existing `netdisco_jobs` Prometheus metrics which expose the same counters via `/metrics`

## Example

```
GET /api/v1/queue/status?since=1h

{
  "queued":  12,
  "running":  4,
  "done":   847,
  "failed":   3,
  "since":  "1h"
}
```

## Test plan

- [x] `GET /api/v1/queue/status` returns counts for all statuses
- [x] `?since=30m` / `?since=2h` / `?since=7d` correctly scopes `done` and `failed`
- [x] `?since=` with invalid format returns 400
- [x] Requires `api_admin` role — returns 401/403 without valid token