### PR TITLE
Improve SNMP exception reporting in job log

### DIFF
--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -335,7 +335,7 @@ sub _try_connect {
       my $err = !defined $ex ? '(undef)'
                        : !ref $ex ? do { (my $e = "$ex") =~ s/ at \S+ line \d+.*//s; $e }
                        : (blessed $ex && $ex->can('message')) ? $ex->message
-                       : (ref $ex eq 'HASH') ? ($ex->{message} || $ex->{error} || join '; ', map { "$_: $ex->{$_}" } sort keys %$ex)
+                       : (ref $ex eq 'HASH') ? ($ex->{message} || $ex->{error} || join('; ', map { "$_: $ex->{$_}" } sort keys %$ex) || '(empty hashref - MCE worker killed or timed out)')
                        : "$ex";
       $err = ref($ex) || '(empty)' unless length $err;
       debug sprintf 'caught error in try_connect: %s', $err;

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -13,6 +13,7 @@ use Try::Tiny;
 use Module::Load ();
 use NetAddr::IP::Lite ':lower';
 use List::Util qw/pairkeys pairfirst/;
+use Scalar::Util 'blessed';
 
 use base 'Dancer::Object::Singleton';
 
@@ -330,7 +331,10 @@ sub _try_connect {
       }
   }
   catch {
-      (my $err = $_) =~ s/ at \S+ line \d+.*//s;
+      my $err = !ref $_ ? do { (my $e = "$_") =~ s/ at \S+ line \d+.*//s; $e }
+                       : (blessed $_ && $_->can('message')) ? $_->message
+                       : (ref $_ eq 'HASH') ? ($_->{message} || $_->{error} || join '; ', map {"$_: $_->{$_}"} sort keys %$_)
+                       : "$_";
       debug sprintf 'caught error in try_connect: %s', $_;
       undef $info;
       die "exception in SNMP - could be job timeout or crash: $err\n";

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -330,9 +330,10 @@ sub _try_connect {
       }
   }
   catch {
+      (my $err = $_) =~ s/ at \S+ line \d+.*//s;
       debug sprintf 'caught error in try_connect: %s', $_;
       undef $info;
-      die "exception in SNMP - could be job timeout or crash\n";
+      die "exception in SNMP - could be job timeout or crash: $err\n";
       # use DDP; debug p $_;
   };
 

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -331,12 +331,13 @@ sub _try_connect {
       }
   }
   catch {
-      my $err = !defined $_ ? '(undef)'
-                       : !ref $_ ? do { (my $e = "$_") =~ s/ at \S+ line \d+.*//s; $e }
-                       : (blessed $_ && $_->can('message')) ? $_->message
-                       : (ref $_ eq 'HASH') ? ($_->{message} || $_->{error} || join '; ', map {"$_: $_->{$_}"} sort keys %$_)
-                       : "$_";
-      $err = ref($_) || '(empty)' unless length $err;
+      my $ex = $_;
+      my $err = !defined $ex ? '(undef)'
+                       : !ref $ex ? do { (my $e = "$ex") =~ s/ at \S+ line \d+.*//s; $e }
+                       : (blessed $ex && $ex->can('message')) ? $ex->message
+                       : (ref $ex eq 'HASH') ? ($ex->{message} || $ex->{error} || join '; ', map { "$_: $ex->{$_}" } sort keys %$ex)
+                       : "$ex";
+      $err = ref($ex) || '(empty)' unless length $err;
       debug sprintf 'caught error in try_connect: %s', $err;
       undef $info;
       die "exception in SNMP - could be job timeout or crash: $err\n";

--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -331,11 +331,13 @@ sub _try_connect {
       }
   }
   catch {
-      my $err = !ref $_ ? do { (my $e = "$_") =~ s/ at \S+ line \d+.*//s; $e }
+      my $err = !defined $_ ? '(undef)'
+                       : !ref $_ ? do { (my $e = "$_") =~ s/ at \S+ line \d+.*//s; $e }
                        : (blessed $_ && $_->can('message')) ? $_->message
                        : (ref $_ eq 'HASH') ? ($_->{message} || $_->{error} || join '; ', map {"$_: $_->{$_}"} sort keys %$_)
                        : "$_";
-      debug sprintf 'caught error in try_connect: %s', $_;
+      $err = ref($_) || '(empty)' unless length $err;
+      debug sprintf 'caught error in try_connect: %s', $err;
       undef $info;
       die "exception in SNMP - could be job timeout or crash: $err\n";
       # use DDP; debug p $_;


### PR DESCRIPTION
When a genuine Perl exception occurs during SNMP connection (as opposed to a normal timeout or auth failure which returns undef quietly), the catch block in `_try_connect` previously always logged the same generic message regardless of what actually went wrong:

```
exception in SNMP - could be job timeout or crash
```

This made it impossible to diagnose the root cause from the job log alone.

After this fix the actual exception is surfaced:

```
exception in SNMP - could be job timeout or crash: Can't call method "new" on an undefined value at .../Transport/SNMP.pm line 251
exception in SNMP - could be job timeout or crash: Can't locate object method "new" via package "SNMP::Info::Layer3::C6500"
```

The stringification handles three cases:
- Plain string exceptions — `at file.pm line N` suffix stripped for readability
- Blessed objects with a `message` method
- Hashrefs — extracts `message`/`error` key, or joins all keys

**Note:** this only applies to code-level exceptions, not normal SNMP failures (wrong community, timeout) which return undef and are reported as `discover failed: could not SNMP connect to <device>` by the worker. The improvement is for the rare but hard-to-debug cases where the SNMP transport itself crashes.

This fix was what surfaced the crashes addressed in #1560 — without readable error messages, those bugs appeared as a generic "could be job timeout or crash" with no indication of the root cause.