### PR TITLE
option to split scheduler and worker for HPA

### DIFF
--- a/bin/netdisco-backend-fg
+++ b/bin/netdisco-backend-fg
@@ -69,11 +69,11 @@ if (setting('workers')->{'no_scheduler'}) {
   shift @task_names; shift @task_workers; shift @task_roles;
 }
 
-warning sprintf "mode: %s | workers: %s | host: %s",
+warning sprintf "mode: %s%s | host: %s",
   (setting('workers')->{'no_scheduler'} ? 'worker-only'
    : $max_workers == 0                  ? 'scheduler'
    :                                      'scheduler+worker'),
-  $max_workers,
+  ($max_workers ? " | workers: $max_workers" : ''),
   (setting('workers')->{'BACKEND'} || 'unknown');
 
 mce_flow {

--- a/bin/netdisco-backend-fg
+++ b/bin/netdisco-backend-fg
@@ -70,7 +70,9 @@ if (setting('workers')->{'no_scheduler'}) {
 }
 
 warning sprintf "mode: %s | workers: %s | host: %s",
-  (setting('workers')->{'no_scheduler'} ? 'worker-only' : 'scheduler+worker'),
+  (setting('workers')->{'no_scheduler'} ? 'worker-only'
+   : $max_workers == 0                  ? 'scheduler'
+   :                                      'scheduler+worker'),
   $max_workers,
   (setting('workers')->{'BACKEND'} || 'unknown');
 

--- a/bin/netdisco-backend-fg
+++ b/bin/netdisco-backend-fg
@@ -53,16 +53,28 @@ my $queue = MCE::Queue->new;
 setting('workers')->{'no_manager'} = 1
   if setting('workers')->{tasks} eq '0';
 
+# support a workers-only node (no scheduler, safe to run multiple replicas)
+setting('workers')->{'no_scheduler'} = 1
+  if $ENV{NETDISCO_NO_SCHEDULER};
+
 # MCE::Util has a limit of ncpu if AUTO is used in max_workers,
 # so we parse the field ourselves.
 my $max_workers = parse_max_workers( setting('workers')->{tasks} ) || 0;
 
+my @task_names   = qw/ scheduler manager poller /;
+my @task_workers = ( 1, 1, $max_workers );
+my @task_roles   = (_mk_wkr('Scheduler'), _mk_wkr('Manager'), _mk_wkr('Poller'));
+
+if (setting('workers')->{'no_scheduler'}) {
+  shift @task_names; shift @task_workers; shift @task_roles;
+}
+
 mce_flow {
-  task_name => [qw/ scheduler manager poller /],
-  max_workers => [ 1, 1, $max_workers ],
-  tmp_dir => $tmp_dir,
+  task_name    => \@task_names,
+  max_workers  => \@task_workers,
+  tmp_dir      => $tmp_dir,
   on_post_exit => sub { MCE->restart_worker },
-}, _mk_wkr('Scheduler'), _mk_wkr('Manager'), _mk_wkr('Poller');
+}, @task_roles;
 
 sub _mk_wkr {
   my $role = shift;

--- a/bin/netdisco-backend-fg
+++ b/bin/netdisco-backend-fg
@@ -69,6 +69,11 @@ if (setting('workers')->{'no_scheduler'}) {
   shift @task_names; shift @task_workers; shift @task_roles;
 }
 
+warning sprintf "mode: %s | workers: %s | host: %s",
+  (setting('workers')->{'no_scheduler'} ? 'worker-only' : 'scheduler+worker'),
+  $max_workers,
+  (setting('workers')->{'BACKEND'} || 'unknown');
+
 mce_flow {
   task_name    => \@task_names,
   max_workers  => \@task_workers,

--- a/lib/App/Netdisco/Configuration.pm
+++ b/lib/App/Netdisco/Configuration.pm
@@ -177,6 +177,10 @@ if ($ENV{ND2_SINGLE_WORKER}) {
   delete config->{'schedule'};
 }
 
+if ($ENV{NETDISCO_NO_SCHEDULER}) {
+  delete config->{'schedule'};
+}
+
 # force skipped DNS resolution, if unset
 setting('dns')->{hosts_file} ||= '/etc/hosts';
 setting('dns')->{no} ||= ['fe80::/64','169.254.0.0/16'];
@@ -369,6 +373,11 @@ if (exists setting('workers')->{interactives}
 
     delete setting('workers')->{pollers};
     delete setting('workers')->{interactives};
+}
+
+# allow container orchestrators to pin worker count via env (e.g. scheduler pod sets this to 0)
+if (exists $ENV{NETDISCO_WORKERS_TASKS}) {
+  setting('workers')->{tasks} = int($ENV{NETDISCO_WORKERS_TASKS});
 }
 
 # moved the timeout setting


### PR DESCRIPTION
## Summary

Adds two environment variables to `netdisco-backend-fg` to enable splitting the backend into separate roles — a single scheduler replica and a horizontally scalable worker replica set.

- **`NETDISCO_NO_SCHEDULER=1`**: disables the scheduler task entirely, making the pod a pure worker node safe to scale with HPA without causing duplicate job scheduling
- **`NETDISCO_WORKERS_TASKS=N`**: overrides the `workers.tasks` config value at runtime, allowing per-Deployment worker tuning without a separate ConfigMap

This is reflected in [netdisco-helm chart **0.4.0**](https://github.com/netdisco/helm-charts/pull/6)  which introduces separate `scheduler` and `worker` Deployments.

## Example k8s setup

```yaml
# scheduler Deployment — 1 replica, no special env
# handles all cron/schedule jobs, never scaled

# worker Deployment — N replicas, HPA-scalable
env:
  - name: NETDISCO_NO_SCHEDULER
    value: "1"
  - name: NETDISCO_WORKERS_TASKS
    value: "20"
```

Startup log is also more verbose depending on the roles:
 - `warn mode: worker-only | workers: 12 | host: netdisco-backend-....`
 - `warn mode: scheduler | host: netdisco-scheduler-... `
 - `warn mode: scheduler+worker | workers: 12 | host: ...` 
## Test plan

- [x] Start backend without env vars — verify `scheduler+worker` mode, schedule jobs fire normally
- [x] Start backend with `NETDISCO_NO_SCHEDULER=1` — verify `worker-only` mode, no scheduler task spawned
- [x] Start backend with `NETDISCO_WORKERS_TASKS=5` — verify worker count overridden
- [x] Run two worker-only pods simultaneously — verify no duplicate job scheduling
