### PR TITLE
fix params() crashing when subaction contains a JSON array

### DIFF
--- a/lib/App/Netdisco/Backend/Job.pm
+++ b/lib/App/Netdisco/Backend/Job.pm
@@ -238,7 +238,10 @@ Returns an empty hashref if subaction is empty or not valid JSON.
 sub params {
   my $job = shift;
   return {} unless $job->subaction;
-  return try { from_json($job->subaction) } catch { {snmp_tag => $job->subaction} };
+  return try {
+    my $r = from_json($job->subaction);
+    ref $r eq 'HASH' ? $r : {}
+  } catch { {snmp_tag => $job->subaction} };
 }
 
 true;


### PR DESCRIPTION
oh no, bug introduced :disappointed: in #1549. it calls `from_json($job->subaction)` and returns whatever JSON decodes to. For arpnip and macsuck "**offline**" jobs the `subaction` field holds the ARP/MAC payload as a JSON **array**. `from_json` succeeds and returns an arrayref, then every caller that dereferences `$job->params` as a hash crashes:

```
Not a HASH reference at .../Worker/Plugin/Internal/SNMPFastDiscover.pm line 14.
```

Three callers are affected:

| File | Expression |
|------|-----------|
| `Internal/SNMPFastDiscover.pm` | `$params->{snmptimeout}` |
| `Discover/Neighbors.pm` | `$job->params->{skip_neighbor_queue}` |
| `Discover/Properties.pm` | `$job->params->{snmp_tag}` |

`SNMPFastDiscover` is a `check`-phase worker and its `error` status (level 4) beats the arpnip/macsuck worker's `done` (level 3) in `finalise_status`, so the job is marked `error` even when the actual data was stored correctly.


Guard in `params()`: if the decoded JSON is not a HASH ref, return `{}`. The plain-string fallback (`snmp_tag`) is unchanged.

```perl
return try {
  my $r = from_json($job->subaction);
  ref $r eq 'HASH' ? $r : {}
} catch { {snmp_tag => $job->subaction} };
```

This is the minimal fix — the interface stays open for future config-merge enhancements discussed in #1549.