### PR TITLE
support NETDISCO_BACKEND_NAME env var to set shared backend identity

### DIFF
--- a/bin/netdisco-backend-fg
+++ b/bin/netdisco-backend-fg
@@ -26,7 +26,7 @@ BEGIN {
   # this can take a few seconds - only do it once
   use Net::Domain 'hostfqdn';
   info 'resolving backend hostname...';
-  setting('workers')->{'BACKEND'} ||= (hostfqdn || 'fqdn-undefined');
+  setting('workers')->{'BACKEND'} ||= ($ENV{NETDISCO_BACKEND_NAME} || hostfqdn || 'fqdn-undefined');
 }
 
 use App::Netdisco::Util::MCE; # set $0 and parse maxworkers


### PR DESCRIPTION
this one was missed for #1565:  In replicated deployments (e.g. Kubernetes HPA), each pod gets a unique FQDN which becomes the `workers.BACKEND` key in `DeviceSkip`. With `max_deferrals` set, each replica tracks skip counts independently, so a device is retried `N*max_deferrals` times instead of `max_deferrals` times total. So basically it reverse the idea of backends in a classic deployment :-) 
