### PR TITLE
fix port lookup in API: uri_unescape and trim captured port name

### DIFF
--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -7,6 +7,9 @@ use Dancer::Plugin::Auth::Extensible;
 
 use App::Netdisco::JobQueue 'jq_insert';
 use Try::Tiny;
+use URI::Escape 'uri_unescape';
+
+sub _port_param { my $s = uri_unescape(shift // ''); $s =~ s/^\s+|\s+$//g; $s }
 
 swagger_path {
   tags => ['Objects'],
@@ -208,7 +211,7 @@ foreach my $rel (qw/nodes active_nodes nodes_with_age active_nodes_with_age port
     }, get qr{/api/v1/object/device/(?<ip>[^/]+)/port/(?<port>.+)/${rel}$} => require_role api => sub {
       my $params = captures;
       my $rows = try { schema(vars->{'tenant'})->resultset('DevicePort')
-        ->find( $$params{port}, $$params{ip} )->$rel }
+        ->find( _port_param($$params{port}), uri_unescape($$params{ip}) )->$rel }
         or send_error('Bad Device or Port', 404);
       return to_json [ map {$_->TO_JSON} $rows->all ];
     };
@@ -235,7 +238,7 @@ foreach my $rel (qw/power properties ssid wireless agg_master neighbor last_node
     }, get qr{/api/v1/object/device/(?<ip>[^/]+)/port/(?<port>.+)/${rel}$} => require_role api => sub {
       my $params = captures;
       my $row = try { schema(vars->{'tenant'})->resultset('DevicePort')
-        ->find( $$params{port}, $$params{ip} )->$rel }
+        ->find( _port_param($$params{port}), uri_unescape($$params{ip}) )->$rel }
         or send_error('Bad Device or Port', 404);
       return to_json $row->TO_JSON;
     };
@@ -262,7 +265,7 @@ swagger_path {
 }, get qr{/api/v1/object/device/(?<ip>[^/]+)/port/(?<port>.+)$} => require_role api => sub {
   my $params = captures;
   my $port = try { schema(vars->{'tenant'})->resultset('DevicePort')
-    ->find( $$params{port}, $$params{ip} ) }
+    ->find( _port_param($$params{port}), uri_unescape($$params{ip}) ) }
     or send_error('Bad Device or Port', 404);
   return to_json $port->TO_JSON;
 };


### PR DESCRIPTION
Dancer's `captures()` does not URL-decode regex path segments, so the per-port API routes in `Web/API/Objects.pm` (`/api/v1/object/device/{ip}/port/{port}` and the nodes/power/etc sub-resources) were passing the raw, still-encoded port name straight to `->find()`.

Any port name containing a slash - basically every stacked/modular switch port like `Gi1/0/1`, sent URL-encoded as `Gi1%2F0%2F1` - never matched, and the API returned a 404 for a port that exists. SNMP-stored port names can also carry stray leading/trailing whitespace, which caused the same kind of false 404.

Example: `GET /api/v1/object/device/10.0.0.1/port/Gi1%2F0%2F1` returned 404 before this fix even though the port is in `device_port`. After decoding and trimming the captured value it resolves correctly.

The fix adds a small `_port_param()` helper that runs the captured port through `uri_unescape()` and strips whitespace before the DB lookup, and applies `uri_unescape()` to the `ip` capture in the same three spots for consistency.