### PR TITLE
feat. make GET /api/v1/object/device batch ready with field selection

### DIFF
--- a/lib/App/Netdisco/Transport/SNMP.pm
+++ b/lib/App/Netdisco/Transport/SNMP.pm
@@ -299,10 +299,11 @@ sub _try_connect {
 
   try {
       $snmp_args->{Offline} || debug
-        sprintf '[%s:%s] try_connect with v: %s, t: %s, r: %s, class: %s, comm: %s',
+        sprintf '[%s:%s] try_connect with v: %s, t: %s, r: %s, class: %s%s, comm: %s',
           $snmp_args->{DestHost}, $snmp_args->{RemotePort},
           $snmp_args->{Version}, ($snmp_args->{Timeout} / 1000000), $snmp_args->{Retries},
-          $class, $debug_comm;
+          $class,
+          ($comm->{tag} ? ', tag: '. $comm->{tag} : ''), $debug_comm;
       Module::Load::load $class;
 
       $info = $class->new(%$snmp_args, %comm_args) or return;

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -15,11 +15,6 @@ swagger_path {
   path => (setting('api_base') || '').'/object/devices',
   description => 'Returns list of all known devices',
   parameters => [
-    q => {
-      in => 'query',
-      description => 'Filter by IP, dns, or name (substring match)',
-      required => 0,
-    },
     fields => {
       in => 'query',
       description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Use "device_auth_tag" to include the cached device auth tag.',
@@ -38,7 +33,6 @@ swagger_path {
   ],
   responses => { default => {} },
 }, get '/api/v1/object/devices' => require_role api => sub {
-  my $q      = params->{q}      || '';
   my $fields = params->{fields} || '';
   my $limit  = params->{limit}  || undef;
   my $offset = params->{offset} || 0;
@@ -49,15 +43,6 @@ swagger_path {
 
   my $want_tag = grep { $_ eq 'device_auth_tag' } @cols;
   @cols = grep { $_ ne 'device_auth_tag' } @cols;
-
-  my %search = ();
-  if ($q) {
-    $search{'-or'} = [
-      { 'me.ip'   => { 'like', "%$q%" } },
-      { 'me.dns'  => { 'like', "%$q%" } },
-      { 'me.name' => { 'like', "%$q%" } },
-    ];
-  }
 
   my %attrs = ( order_by => 'me.dns' );
   $attrs{columns} = \@cols if @cols;
@@ -71,7 +56,7 @@ swagger_path {
 
   my @devices = try {
     schema(vars->{'tenant'})->resultset('Device')
-      ->search(\%search, \%attrs)->hri->all;
+      ->search(undef, \%attrs)->hri->all;
   } catch { () };
 
   return to_json \@devices;

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -25,11 +25,23 @@ swagger_path {
       description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column.',
       required => 0,
     },
+    limit => {
+      in => 'query',
+      description => 'Maximum number of devices to return. Default: all.',
+      required => 0,
+    },
+    offset => {
+      in => 'query',
+      description => 'Number of devices to skip (for paging). Default: 0.',
+      required => 0,
+    },
   ],
   responses => { default => {} },
 }, get '/api/v1/object/devices' => require_role api => sub {
   my $q      = params->{q}      || '';
   my $fields = params->{fields} || '';
+  my $limit  = params->{limit}  || undef;
+  my $offset = params->{offset} || 0;
 
   my @cols = $fields eq 'all'  ? ()
            : $fields           ? split(/\s*,\s*/, $fields)
@@ -46,6 +58,8 @@ swagger_path {
 
   my %attrs = ( order_by => 'me.dns' );
   $attrs{columns} = \@cols if @cols;
+  $attrs{rows}   = int($limit)  if $limit;
+  $attrs{offset} = int($offset) if $offset;
 
   my @devices = try {
     schema(vars->{'tenant'})->resultset('Device')

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -17,7 +17,7 @@ swagger_path {
   parameters => [
     fields => {
       in => 'query',
-      description => 'Comma-separated list of fields to return. Default: ip,dns,name. Use "all" for every column. Extra: vendor,model,os,os_ver,location,last_discover,device_auth_tag.',
+      description => 'Comma-separated list of fields to return. Default: ip,dns,name. Any device table column is valid (e.g. vendor,model,os,os_ver,location,layers,last_discover,last_macsuck,last_arpnip). Use "all" for every column. Extra join: device_auth_tag.',
       required => 0,
     },
     limit => {

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -22,7 +22,7 @@ swagger_path {
     },
     fields => {
       in => 'query',
-      description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column.',
+      description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Use "snmp_auth_tag" to include the cached SNMP auth tag.',
       required => 0,
     },
     limit => {
@@ -47,6 +47,9 @@ swagger_path {
            : $fields           ? split(/\s*,\s*/, $fields)
            :                     @DEVICE_FIELDS;
 
+  my $want_tag = grep { $_ eq 'snmp_auth_tag' } @cols;
+  @cols = grep { $_ ne 'snmp_auth_tag' } @cols;
+
   my %search = ();
   if ($q) {
     $search{'-or'} = [
@@ -60,6 +63,11 @@ swagger_path {
   $attrs{columns} = \@cols if @cols;
   $attrs{rows}   = int($limit)  if $limit;
   $attrs{offset} = int($offset) if $offset;
+
+  if ($want_tag) {
+    $attrs{join} = 'community';
+    push @{ $attrs{'+columns'} }, { snmp_auth_tag => 'community.snmp_auth_tag_read' };
+  }
 
   my @devices = try {
     schema(vars->{'tenant'})->resultset('Device')

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -22,7 +22,7 @@ swagger_path {
     },
     fields => {
       in => 'query',
-      description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Use "snmp_auth_tag" to include the cached SNMP auth tag.',
+      description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Use "device_auth_tag" to include the cached device auth tag.',
       required => 0,
     },
     limit => {
@@ -47,8 +47,8 @@ swagger_path {
            : $fields           ? split(/\s*,\s*/, $fields)
            :                     @DEVICE_FIELDS;
 
-  my $want_tag = grep { $_ eq 'snmp_auth_tag' } @cols;
-  @cols = grep { $_ ne 'snmp_auth_tag' } @cols;
+  my $want_tag = grep { $_ eq 'device_auth_tag' } @cols;
+  @cols = grep { $_ ne 'device_auth_tag' } @cols;
 
   my %search = ();
   if ($q) {
@@ -66,7 +66,7 @@ swagger_path {
 
   if ($want_tag) {
     $attrs{join} = 'community';
-    push @{ $attrs{'+columns'} }, { snmp_auth_tag => 'community.snmp_auth_tag_read' };
+    push @{ $attrs{'+columns'} }, { device_auth_tag => 'community.snmp_auth_tag_read' };
   }
 
   my @devices = try {

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -17,7 +17,7 @@ swagger_path {
   parameters => [
     fields => {
       in => 'query',
-      description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Use "device_auth_tag" to include the cached device auth tag.',
+      description => 'Comma-separated list of fields to return. Default: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Extra: device_auth_tag.',
       required => 0,
     },
     limit => {

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -8,6 +8,53 @@ use Dancer::Plugin::Auth::Extensible;
 use App::Netdisco::JobQueue 'jq_insert';
 use Try::Tiny;
 
+my @DEVICE_FIELDS = qw/ip dns name vendor model os os_ver location last_discover/;
+
+swagger_path {
+  tags => ['Objects'],
+  path => (setting('api_base') || '').'/object/devices',
+  description => 'Returns list of all known devices',
+  parameters => [
+    q => {
+      in => 'query',
+      description => 'Filter by IP, dns, or name (substring match)',
+      required => 0,
+    },
+    fields => {
+      in => 'query',
+      description => 'Comma-separated list of fields to return. Defaults to: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column.',
+      required => 0,
+    },
+  ],
+  responses => { default => {} },
+}, get '/api/v1/object/devices' => require_role api => sub {
+  my $q      = params->{q}      || '';
+  my $fields = params->{fields} || '';
+
+  my @cols = $fields eq 'all'  ? ()
+           : $fields           ? split(/\s*,\s*/, $fields)
+           :                     @DEVICE_FIELDS;
+
+  my %search = ();
+  if ($q) {
+    $search{'-or'} = [
+      { 'me.ip'   => { 'like', "%$q%" } },
+      { 'me.dns'  => { 'like', "%$q%" } },
+      { 'me.name' => { 'like', "%$q%" } },
+    ];
+  }
+
+  my %attrs = ( order_by => 'me.dns' );
+  $attrs{columns} = \@cols if @cols;
+
+  my @devices = try {
+    schema(vars->{'tenant'})->resultset('Device')
+      ->search(\%search, \%attrs)->hri->all;
+  } catch { () };
+
+  return to_json \@devices;
+};
+
 swagger_path {
   tags => ['Objects'],
   path => (setting('api_base') || '').'/object/device/{ip}',

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -8,7 +8,7 @@ use Dancer::Plugin::Auth::Extensible;
 use App::Netdisco::JobQueue 'jq_insert';
 use Try::Tiny;
 
-my @DEVICE_FIELDS = qw/ip dns name vendor model os os_ver location last_discover/;
+my @DEVICE_FIELDS = qw/ip dns name/;
 
 swagger_path {
   tags => ['Objects'],
@@ -17,7 +17,7 @@ swagger_path {
   parameters => [
     fields => {
       in => 'query',
-      description => 'Comma-separated list of fields to return. Default: ip,dns,name,vendor,model,os,os_ver,location,last_discover. Use "all" for every column. Extra: device_auth_tag.',
+      description => 'Comma-separated list of fields to return. Default: ip,dns,name. Use "all" for every column. Extra: vendor,model,os,os_ver,location,last_discover,device_auth_tag.',
       required => 0,
     },
     limit => {

--- a/lib/App/Netdisco/Web/API/Objects.pm
+++ b/lib/App/Netdisco/Web/API/Objects.pm
@@ -8,60 +8,6 @@ use Dancer::Plugin::Auth::Extensible;
 use App::Netdisco::JobQueue 'jq_insert';
 use Try::Tiny;
 
-my @DEVICE_FIELDS = qw/ip dns name/;
-
-swagger_path {
-  tags => ['Objects'],
-  path => (setting('api_base') || '').'/object/devices',
-  description => 'Returns list of all known devices',
-  parameters => [
-    fields => {
-      in => 'query',
-      description => 'Comma-separated list of fields to return. Default: ip,dns,name. Any device table column is valid (e.g. vendor,model,os,os_ver,location,layers,last_discover,last_macsuck,last_arpnip). Use "all" for every column. Extra join: device_auth_tag.',
-      required => 0,
-    },
-    limit => {
-      in => 'query',
-      description => 'Maximum number of devices to return. Default: all.',
-      required => 0,
-    },
-    offset => {
-      in => 'query',
-      description => 'Number of devices to skip (for paging). Default: 0.',
-      required => 0,
-    },
-  ],
-  responses => { default => {} },
-}, get '/api/v1/object/devices' => require_role api => sub {
-  my $fields = params->{fields} || '';
-  my $limit  = params->{limit}  || undef;
-  my $offset = params->{offset} || 0;
-
-  my @cols = $fields eq 'all'  ? ()
-           : $fields           ? split(/\s*,\s*/, $fields)
-           :                     @DEVICE_FIELDS;
-
-  my $want_tag = grep { $_ eq 'device_auth_tag' } @cols;
-  @cols = grep { $_ ne 'device_auth_tag' } @cols;
-
-  my %attrs = ( order_by => 'me.dns' );
-  $attrs{columns} = \@cols if @cols;
-  $attrs{rows}   = int($limit)  if $limit;
-  $attrs{offset} = int($offset) if $offset;
-
-  if ($want_tag) {
-    $attrs{join} = 'community';
-    push @{ $attrs{'+columns'} }, { device_auth_tag => 'community.snmp_auth_tag_read' };
-  }
-
-  my @devices = try {
-    schema(vars->{'tenant'})->resultset('Device')
-      ->search(undef, \%attrs)->hri->all;
-  } catch { () };
-
-  return to_json \@devices;
-};
-
 swagger_path {
   tags => ['Objects'],
   path => (setting('api_base') || '').'/object/device/{ip}',

--- a/lib/App/Netdisco/Web/Plugin/Search/Device.pm
+++ b/lib/App/Netdisco/Web/Plugin/Search/Device.pm
@@ -96,13 +96,13 @@ get '/ajax/content/search/device' => require_login sub {
 
     my $rs;
     if ($has_opt) {
-        $rs = $rs_columns->with_times->search_by_field( scalar params );
+        $rs = $rs_columns->search_by_field( scalar params );
     }
     elsif (param('q')) {
-        $rs = $rs_columns->with_times->search_fuzzy( param('q') );
+        $rs = $rs_columns->search_fuzzy( param('q') );
     }
     elsif (defined param('limit') and defined param('offset')) {
-        $rs = $rs_columns->with_times->search(undef, { order_by => [qw/me.dns me.ip/] });
+        $rs = $rs_columns->search(undef, { order_by => [qw/me.dns me.ip/] });
     }
     else {
         send_error( 'Missing query - provide "q", a filter parameter,'
@@ -111,12 +111,24 @@ get '/ajax/content/search/device' => require_login sub {
 
     my $limit  = param('limit');
     my $offset = param('offset');
-    my %page_attrs;
-    $page_attrs{rows}   = int($limit)  if $limit;
-    $page_attrs{offset} = int($offset) if $offset;
-    $rs = $rs->search(undef, \%page_attrs) if %page_attrs;
 
-    my @results = $rs->with_module_serials # must come after search_fuzzy
+    if ($limit or $offset) {
+        # paginate on device ip before with_times/with_module_serials: combining
+        # LIMIT with the module_serials has_many join forces DBIC to wrap the
+        # query in a subquery, which cannot re-express with_times' raw-SQL
+        # computed columns (eg. me.creation) in the outer SELECT, and crashes
+        my @page_ips = $rs->search(undef, {
+          columns => ['ip'],
+          ($limit  ? (rows   => int($limit))  : ()),
+          ($offset ? (offset => int($offset)) : ()),
+        })->get_column('ip')->all;
+        return unless @page_ips;
+
+        $rs = $rs_columns->search({ 'me.ip' => { -in => \@page_ips } },
+                                   { order_by => [qw/me.dns me.ip/] });
+    }
+
+    my @results = $rs->with_times->with_module_serials # must come after search_fuzzy
                      ->hri->all;
     return unless scalar @results;
 

--- a/lib/App/Netdisco/Web/Plugin/Search/Device.pm
+++ b/lib/App/Netdisco/Web/Plugin/Search/Device.pm
@@ -60,6 +60,11 @@ register_search_tab({
       fields => {
         description => 'Comma-separated list of fields to return. Default: ip,dns,name,location,model,os_ver,serial,chassis_id. Any Device table column is valid (e.g. vendor,os,layers,last_discover,last_macsuck,last_arpnip). Use "all" for every column. Extra join: device_auth_tag.',
       },
+      seeallcolumns => {
+        description => 'Deprecated, use fields=all instead. If true and "fields" is not given, all columns of the Device will be shown.',
+        type => 'boolean',
+        default => 'false',
+      },
       limit => {
         description => 'Maximum number of devices to return. Required, along with "offset", if neither "q" nor any filter parameter is given.',
       },
@@ -74,7 +79,7 @@ get '/ajax/content/search/device' => require_login sub {
     my $has_opt = List::MoreUtils::any { param($_) }
       qw/name location dns ip description model os os_ver vendor layers mac/;
 
-    my $fields = param('fields') || '';
+    my $fields = param('fields') || (param('seeallcolumns') ? 'all' : '');
     my @cols = $fields eq 'all' ? ()
              : $fields          ? split(/\s*,\s*/, $fields)
              :                    @DEFAULT_FIELDS;

--- a/lib/App/Netdisco/Web/Plugin/Search/Device.pm
+++ b/lib/App/Netdisco/Web/Plugin/Search/Device.pm
@@ -8,6 +8,8 @@ use List::MoreUtils ();
 
 use App::Netdisco::Web::Plugin;
 
+my @DEFAULT_FIELDS = qw/ip dns name location model os_ver serial chassis_id/;
+
 register_search_tab({
     tag => 'device',
     label => 'Device',
@@ -15,7 +17,7 @@ register_search_tab({
     api_endpoint => 1,
     api_parameters => [
       q => {
-        description => 'Partial match of Device contact, serial, chassis ID, module serials, location, name, description, dns, or any IP alias',
+        description => 'Partial match of Device contact, serial, chassis ID, module serials, location, name, description, dns, or any IP alias. Optional if "limit" and "offset" are both given, to return all devices.',
       },
       name => {
         description => 'Partial match of the Device name',
@@ -55,10 +57,14 @@ register_search_tab({
         type => 'boolean',
         default => 'false',
       },
-      seeallcolumns => {
-        description => 'If true, all columns of the Device will be shown',
-        type => 'boolean',
-        default => 'false',
+      fields => {
+        description => 'Comma-separated list of fields to return. Default: ip,dns,name,location,model,os_ver,serial,chassis_id. Any Device table column is valid (e.g. vendor,os,layers,last_discover,last_macsuck,last_arpnip). Use "all" for every column. Extra join: device_auth_tag.',
+      },
+      limit => {
+        description => 'Maximum number of devices to return. Required, along with "offset", if neither "q" nor any filter parameter is given.',
+      },
+      offset => {
+        description => 'Number of devices to skip (for paging). Default: 0.',
       },
     ],
 });
@@ -67,30 +73,43 @@ register_search_tab({
 get '/ajax/content/search/device' => require_login sub {
     my $has_opt = List::MoreUtils::any { param($_) }
       qw/name location dns ip description model os os_ver vendor layers mac/;
+
+    my $fields = param('fields') || '';
+    my @cols = $fields eq 'all' ? ()
+             : $fields          ? split(/\s*,\s*/, $fields)
+             :                    @DEFAULT_FIELDS;
+
+    my $want_tag = List::MoreUtils::any { $_ eq 'device_auth_tag' } @cols;
+    @cols = grep { $_ ne 'device_auth_tag' } @cols;
+
+    my $rs_columns = schema(vars->{'tenant'})->resultset('Device');
+    $rs_columns = $rs_columns->columns(\@cols) if @cols;
+    $rs_columns = $rs_columns->search(undef, {
+      join => 'community',
+      '+columns' => [{ device_auth_tag => 'community.snmp_auth_tag_read' }],
+    }) if $want_tag;
+
     my $rs;
-    my $rs_columns;
-    my $see_all = param('seeallcolumns');
-
-    if ($see_all) {
-      $rs_columns = schema(vars->{'tenant'})->resultset('Device');
-    }
-    else {
-      $rs_columns = schema(vars->{'tenant'})->resultset('Device')->columns(
-            [   "ip",       "dns",   "name",
-                "location", "model", "os_ver", "serial", "chassis_id"
-            ]
-        );
-    }
-
     if ($has_opt) {
         $rs = $rs_columns->with_times->search_by_field( scalar params );
     }
-    else {
-        my $q = param('q');
-        send_error( 'Missing query', 400 ) unless $q;
-
-        $rs = $rs_columns->with_times->search_fuzzy($q);
+    elsif (param('q')) {
+        $rs = $rs_columns->with_times->search_fuzzy( param('q') );
     }
+    elsif (defined param('limit') and defined param('offset')) {
+        $rs = $rs_columns->with_times->search(undef, { order_by => [qw/me.dns me.ip/] });
+    }
+    else {
+        send_error( 'Missing query - provide "q", a filter parameter,'
+          .' or both "limit" and "offset"', 400 );
+    }
+
+    my $limit  = param('limit');
+    my $offset = param('offset');
+    my %page_attrs;
+    $page_attrs{rows}   = int($limit)  if $limit;
+    $page_attrs{offset} = int($offset) if $offset;
+    $rs = $rs->search(undef, \%page_attrs) if %page_attrs;
 
     my @results = $rs->with_module_serials # must come after search_fuzzy
                      ->hri->all;


### PR DESCRIPTION
Adds `GET /api/v1/object/devices`, a bulk device list endpoint. Unlike `/api/v1/search/device`, which requires at least one filter param (`q`, `name`, `location`, etc.) and returns a fixed set of columns unless `seeallcolumns` is set, this endpoint returns the full device inventory (or a page of it) with a caller-chosen column list and no filtering required.

Main use case is comparing/syncing against external systems (CMDB, monitoring) where you want the whole inventory, or a specific subset of fields across all devices, rather than a filtered lookup. Supports `fields` (comma-separated column list, `all` for every column, plus a `device_auth_tag` join extra), `limit` and `offset` for paging large inventories.

Example: `GET /api/v1/object/devices?fields=ip,dns,vendor,device_auth_tag&limit=100&offset=200`.

Happy to fold this into `/search/device` instead if you'd prefer one endpoint - it just seemed like a bigger change since that route currently requires a filter and only supports the fixed/all column set, so relaxing that would affect every other search tab using the same dispatcher. Let me know if you'd rather go that route.


on the other side wondering if a simple q parameter like https://github.com/netdisco/netdisco/pull/1584/changes/2f85f24edc9efbe648234629166931f146d87efc could make sense or if we conflict with the idea... :) 