### PR TITLE
fix uninitialized value warning when daterange param is absent

### DIFF
--- a/lib/App/Netdisco/Web/Plugin/Search/Node.pm
+++ b/lib/App/Netdisco/Web/Plugin/Search/Node.pm
@@ -68,7 +68,7 @@ get '/ajax/content/search/node' => require_login sub {
     content_type('text/html');
 
     my $agenot = param('age_invert') || '0';
-    my ( $start, $end ) = param('daterange') =~ m/(\d+-\d+-\d+)/gmx;
+    my ( $start, $end ) = (param('daterange') // '') =~ m/(\d+-\d+-\d+)/gmx;
 
     my $mac = NetAddr::MAC->new(mac => ($node || ''));
     undef $mac if


### PR DESCRIPTION
Low relevance/cosmetic fix. param('daterange') returns undef when the node search is run without a daterange filter (the common case), and matching a regex against undef throws a Perl "Use of uninitialized value" warning on every such search - no functional impact, just log noise. Coerces to empty string first so the match is a silent no-op instead.