### PR TITLE
fix /api/ endpoints returning HTML when Accept header is missing

### DIFF
--- a/lib/App/Netdisco/Util/Web.pm
+++ b/lib/App/Netdisco/Util/Web.pm
@@ -57,12 +57,12 @@ Client has requested JSON format data and an endpoint under C</api>.
 =cut
 
 sub request_is_api {
-  return ((request->accept and request->accept =~ m/(?:json|javascript)/) and (
-    index(request->path, uri_for('/api/')->path) == 0
-      or
-    (param('return_url')
-    and index(param('return_url'), uri_for('/api/')->path) == 0)
-  ));
+  # /api/ paths are always API endpoints regardless of Accept header
+  return 1 if index(request->path, uri_for('/api/')->path) == 0;
+  # for other paths, require Accept: json and a return_url pointing to /api/
+  return ((request->accept and request->accept =~ m/(?:json|javascript)/)
+    and param('return_url')
+    and index(param('return_url'), uri_for('/api/')->path) == 0);
 }
 
 =head2 request_is_api_report


### PR DESCRIPTION
request_is_api() previously required Accept: application/json even for paths under /api/v1/. Two consequences: send_error() (lib/App/Netdisco/Web.pm) would render a full HTML Dancer error page instead of a clean {error: ...} JSON body, and the Bearer token auth branch in AuthN.pm wouldn't even trigger, so a request with just an Authorization header and no explicit Accept would fall through to session/login handling.

In practice this shows up as: curl https://host/api/v1/object/devices with a Bearer token but no -H "Accept: application/json" gets ignored auth and/or a wall of HTML instead of JSON, which is annoying when quickly curling/debugging the API.

Fix treats any path under /api/ as unambiguously an API request regardless of Accept header, since there's no other client of that path prefix. The Accept-header check is kept for the other case (non-/api/ paths with a return_url pointing back to /api/), which is unchanged.

Not fully sure this is the right fix vs. e.g. checking the Authorization header presence instead - open to a different approach if you see a cleaner one.