### PR TITLE
new setting expire_nodeip_orphans

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Expire.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Expire.pm
@@ -79,13 +79,15 @@ register_worker({ phase => 'main' }, sub {
       });
   }
 
-  # also have to clean up node_ip that have no correspoding node
-  schema('netdisco')->resultset('NodeIp')->search({
-    mac => { -in => schema('netdisco')->resultset('NodeIp')->search(
-      { port => undef },
-      { join => 'nodes', select => [{ distinct => 'me.mac' }], }
-    )->as_query },
-  })->delete;
+  # also clean up node_ip entries that have no corresponding node
+  if (setting('expire_nodeip_orphans')) {
+      schema('netdisco')->resultset('NodeIp')->search({
+        mac => { -in => schema('netdisco')->resultset('NodeIp')->search(
+          { port => undef },
+          { join => 'nodes', select => [{ distinct => 'me.mac' }], }
+        )->as_query },
+      })->delete;
+  }
 
   if (setting('expire_jobs') and setting('expire_jobs') > 0) {
       schema('netdisco')->txn_do_locked('admin', EXCLUSIVE, sub {

--- a/share/config.yml
+++ b/share/config.yml
@@ -725,6 +725,7 @@ expire_nodes_archive: 60
 expire_jobs: 14
 expire_userlog: 365
 expire_nodeip_freshness: null
+expire_nodeip_orphans: true
 store_wireless_clients: true
 skip_neighbors: []
 neighbor_no_type: []


### PR DESCRIPTION
new setting expire_nodeip_orphans

 - set to true, expire immediately deletes node_ip entries without matching node entry - this is the original behavior and stays enabled by default
 - set to false, node_ip entries will remain in the table until a time-based limit from expire_nodes or expire_nodeip_freshness is met

This allows Netdisco to keep potentially interesting node_ip entries, even if the environment can not provide node entries