### PR TITLE
Refuse to empty snmp_object when the MIB reports parse to nothing

### DIFF
--- a/bin/netdisco-do
+++ b/bin/netdisco-do
@@ -549,6 +549,9 @@ Pass a device in C<-d> to display them:
 A requirement for web browsing of SNMP data (see C<snapshot> command), run
 this to load Netdisco MIBs into the database. It only needs to be done once.
 
+If the MIB reports parse to nothing, the job leaves the C<snmp_object> table
+unchanged, logs the reason, and exits non-zero.
+
 =head2 snapshot
 
 Builds and saves a data structure which Netdisco can use to mimic the device

--- a/lib/App/Netdisco/Worker/Plugin/LoadMIBs.pm
+++ b/lib/App/Netdisco/Worker/Plugin/LoadMIBs.pm
@@ -35,8 +35,12 @@ register_worker({ phase => 'main' }, sub {
       push @report, read_lines( catfile( $reports, "${vendor}_oids" ), 'latin-1' );
   }
   else {
+      my %seen_report = ();
+      my @to_read = grep { not $seen_report{$_}++ }
+                    (qw(rfc_oids net-snmp_oids cisco_oids), @maps);
+
       push @report, read_lines( catfile( $reports, $_ ), 'latin-1' )
-        for (qw(rfc_oids net-snmp_oids cisco_oids), @maps);
+        for @to_read;
   }
   
   my @browser = ();

--- a/lib/App/Netdisco/Worker/Plugin/LoadMIBs.pm
+++ b/lib/App/Netdisco/Worker/Plugin/LoadMIBs.pm
@@ -78,12 +78,24 @@ register_worker({ phase => 'main' }, sub {
   debug sprintf "loadmibs - loaded %d objects from netdisco-mibs",
     scalar @browser;
 
-  schema('netdisco')->txn_do(sub {
-    my $gone = schema('netdisco')->resultset('SNMPObject')->delete;
-    debug sprintf 'loadmibs - removed %d oids', $gone;
-    schema('netdisco')->resultset('SNMPObject')->populate(\@browser);
-    debug sprintf 'loadmibs - added %d new oids', scalar @browser;
-  });
+  if (not scalar @browser) {
+    my $refusal = sprintf
+      'loadmibs - refusing to empty snmp_object: read %d lines from %s but '
+    . 'parsed 0 objects', scalar @report, $reports;
+
+    # error() is what survives --quiet on the console. add_status() records the
+    # refusal now so the blocks below still run and cannot displace it.
+    error $refusal;
+    $job->add_status( Status->error($refusal) );
+  }
+  else {
+    schema('netdisco')->txn_do(sub {
+      my $gone = schema('netdisco')->resultset('SNMPObject')->delete;
+      debug sprintf 'loadmibs - removed %d oids', $gone;
+      schema('netdisco')->resultset('SNMPObject')->populate(\@browser);
+      debug sprintf 'loadmibs - added %d new oids', scalar @browser;
+    });
+  }
 
   # promote snapshots prior to loadmibs to be browsable
   schema('netdisco')->txn_do(sub {

--- a/xt/31-loadmibs-guard.t
+++ b/xt/31-loadmibs-guard.t
@@ -1,0 +1,240 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+BEGIN { $ENV{DANCER_ENVDIR} = '/dev/null'; }
+
+use Test::More 0.88;
+use Test::File::ShareDir::Dist { 'App-Netdisco' => 'share/' };
+
+use File::Temp ();
+use File::Path 'make_path';
+use File::Spec::Functions 'catfile';
+
+use App::Netdisco;
+use App::Netdisco::Backend::Job;
+use App::Netdisco::Worker::Plugin::LoadMIBs ();
+
+use Try::Tiny;
+use Dancer qw/:moose :script !pass/;
+use Dancer::Logger::Capture ();
+
+# Capture rather than print: the guard reports its refusal at error level, so a
+# clean run would otherwise show it every time. Subtest 1 reads the trap, which
+# is the only coverage of the error() call. DANCER_DEBUG restores the console.
+my $CONFIG = config();
+$CONFIG->{logger} = ($ENV{'DANCER_DEBUG'} ? 'console' : 'capture');
+$CONFIG->{log} = 'debug';
+Dancer::Logger->init($CONFIG->{logger}, $CONFIG);
+
+# The schema is replaced with a stand-in that records the statements it is asked
+# for and returns nothing, so this file needs no database, like the rest of xt/.
+# The blocks after the guard are therefore proved entered, not proved to work.
+# ND2_DB_ROLLBACK is not an alternative: Runner.pm opens its transaction guard
+# through its own schema, which this does not cover, and the file would then
+# need a live server. our() is a lexical alias, so the packages below can use
+# @STATEMENTS unqualified.
+our @STATEMENTS = ();
+
+# Set by the third subtest to make a block after the guard fail, which is the
+# situation the worker's add_status call exists for.
+our $BREAK_LATER_BLOCKS = 0;
+
+{
+  package FakeResultSet;
+  sub new        { bless { name => $_[1] }, $_[0] }
+  sub delete     { push @STATEMENTS, "delete $_[0]{name}"; return 0 }
+  sub populate   { push @STATEMENTS, "populate $_[0]{name} " . scalar @{ $_[1] }; return 1 }
+  sub search     { return $_[0] }
+  sub distinct   { return $_[0] }
+  sub get_column { return $_[0] }
+  sub all        { return () }
+  sub count      { return 0 }
+}
+
+{
+  package FakeSchema;
+  sub resultset {
+    push @STATEMENTS, "resultset $_[1]";
+    die "simulated failure in a later block\n"
+      if $BREAK_LATER_BLOCKS and $_[1] eq 'DeviceBrowser';
+    return FakeResultSet->new($_[1]);
+  }
+  sub txn_do    { return $_[1]->() }
+}
+
+# The plugin must already be loaded, hence the use above: its own
+# "use Dancer::Plugin::DBIC 'schema'" would otherwise install the real schema
+# after this assignment and undo it.
+{
+  no warnings 'redefine';
+  *App::Netdisco::Worker::Plugin::LoadMIBs::schema = sub { bless {}, 'FakeSchema' };
+}
+
+{
+  package MyWorker;
+  use Moo;
+  with 'App::Netdisco::Worker::Runner';
+}
+
+# netdisco-mibs 4.054 onwards ships EXTRAS/reports as git-lfs pointer stubs,
+# because GitHub tag archives do not resolve LFS. The files exist and parse to
+# nothing, which is the silent case: 4.053 shipped no *_oids files at all, so
+# the read dies before ever reaching the guard.
+#
+# juniper_oids is here so the line count can tell the dedupe apart from dropping
+# @maps altogether: without it every file is one of the three hardcoded names
+# and both regressions read the same number of lines. It is reached through the
+# *_oids glob, so a TMPDIR containing a dot drops it (see LoadMIBs.pm:29) and
+# the count assertion fails rather than passing for the wrong reason.
+sub mibhome_with_lfs_stubs {
+  my $home = File::Temp->newdir();
+  my $reports = catfile("$home", 'EXTRAS', 'reports');
+  make_path($reports);
+  foreach my $report (qw/rfc_oids net-snmp_oids cisco_oids juniper_oids/) {
+      open my $fh, '>', catfile($reports, $report) or die $!;
+      print {$fh} "version https://git-lfs.github.com/spec/v1\n"
+                . "oid sha256:0000000000000000000000000000000000000000000000000000000000000000\n"
+                . "size 12345\n";
+      close $fh;
+  }
+  return $home;
+}
+
+# A parseable report line: oid, MIB::leaf, type, access, index, status, enum, descr.
+sub mibhome_with_valid_reports {
+  my $home = File::Temp->newdir();
+  my $reports = catfile("$home", 'EXTRAS', 'reports');
+  make_path($reports);
+  foreach my $report (qw/rfc_oids net-snmp_oids cisco_oids/) {
+      open my $fh, '>', catfile($reports, $report) or die $!;
+      print {$fh} ".1.3.6.1.2.1.1.1,SNMPv2-MIB::sysDescr,OCTET STRING,"
+                . "read-only,,current,,A textual description of the entity\n";
+      close $fh;
+  }
+  return $home;
+}
+
+sub run_loadmibs {
+  my ($mibhome, $vendor) = @_;
+  @STATEMENTS = ();
+  config->{'mibhome'} = "$mibhome";
+  # subaction, not extra: extra is a read-only alias for it (Job.pm:229) and is
+  # not a constructor slot, so Moo drops it and the vendor branch never runs.
+  my $job = App::Netdisco::Backend::Job->new({
+    job => 0, action => 'loadmibs', ($vendor ? (subaction => $vendor) : ()) });
+  try { MyWorker->new()->run($job) } catch { diag "unexpected exception: $_" };
+  return $job;
+}
+
+subtest 'loadmibs__reports_are_lfs_stubs__refuses_without_deleting' => sub {
+    my $job = run_loadmibs( mibhome_with_lfs_stubs() );
+
+    is $job->status, 'error',
+      'the job reports failure rather than success'
+      or diag $job->log;
+
+    like $job->log, qr/refusing to empty snmp_object/,
+      'and says the table was deliberately left alone';
+
+    # error() rather than the status list, because that is the only thing a
+    # --quiet operator sees: netdisco-do raises the log level to error, which
+    # suppresses both add_status's debug line and its own closing status line.
+    SKIP: {
+        skip 'console logger in use under DANCER_DEBUG', 1 if $ENV{'DANCER_DEBUG'};
+        ok scalar(grep { $_->{level} eq 'error'
+                         and $_->{message} =~ m/refusing to empty snmp_object/ }
+                  @{ Dancer::Logger::Capture->trap->read }),
+          'and logged the refusal at error level';
+    }
+
+    # Four files at three lines each, read once. Reverting the dedupe gives 21
+    # because the glob repeats the three hardcoded names; dropping @maps gives
+    # 9 because juniper_oids is only reachable through the glob.
+    like $job->log, qr/\bread 12 lines\b/,
+      'each report file was read exactly once';
+
+    # Anchored, so a future line that merely counts the preserved rows does not
+    # read as a delete.
+    is_deeply [ grep { m/^(?:delete|populate) SNMPObject/ } @STATEMENTS ], [],
+      'the load branch never touched snmp_object'
+      or diag join "\n", @STATEMENTS;
+
+    # Only the load is skipped. Promotion reads the table the refusal just
+    # preserved; the legacy upgrade is unrelated work that should not become
+    # collateral damage. The count tells the two blocks apart, which their
+    # resultset names cannot, and is one per txn_do block: change it only on
+    # purpose.
+    is scalar(grep { m/^resultset DeviceBrowser/ } @STATEMENTS), 2,
+      'snapshot promotion and the legacy upgrade both still ran'
+      or diag join "\n", @STATEMENTS;
+
+    # A stand-in that has fallen behind the worker's resultset calls dies in a
+    # later block, and finalise_status prefers the earliest error, so the
+    # refusal keeps status and log. Drift in the last stand-in method reaches
+    # only this assertion, which is what earns it its place. Vacuous on an empty
+    # status list, which the refusal assertion above rules out: the status
+    # assertion cannot, because finalise_status falls back to error on an empty
+    # list.
+    is_deeply [ grep { $_->status eq 'error'
+                       and ($_->log // '') !~ m/refusing to empty snmp_object/ }
+                @{ $job->_statuslist } ], [],
+      'the refusal is the only error, so nothing after the guard failed'
+      or diag join "\n", map { $_->log // '' } @{ $job->_statuslist };
+};
+
+subtest 'loadmibs__reports_parse_to_objects__does_not_refuse' => sub {
+    my $job = run_loadmibs( mibhome_with_valid_reports() );
+
+    is $job->status, 'done',
+      'the job succeeds'
+      or diag $job->log;
+
+    unlike $job->log, qr/refusing to empty snmp_object/,
+      'the guard does not fire when objects were parsed';
+
+    is_deeply [ grep { m/^(?:delete|populate) SNMPObject/ } @STATEMENTS ],
+      [ 'delete SNMPObject', 'populate SNMPObject 1' ],
+      'the table is replaced, in that order'
+      or diag join "\n", @STATEMENTS;
+};
+
+# The worker records the refusal as the job's outcome the moment it decides,
+# rather than only returning it at the end, because the blocks after the guard
+# act on other tables and can fail on their own. Without that, the exception
+# below would become the outcome and the refusal would never reach the operator.
+subtest 'loadmibs__a_later_block_dies__still_reports_the_refusal' => sub {
+    local $BREAK_LATER_BLOCKS = 1;
+    my $job = run_loadmibs( mibhome_with_lfs_stubs() );
+
+    like $job->log, qr/refusing to empty snmp_object/,
+      'the refusal is the outcome, not the later failure'
+      or diag join "\n", map { $_->log // '' } @{ $job->_statuslist };
+
+    ok scalar(grep { ($_->log // '') =~ m/simulated failure/ }
+                  @{ $job->_statuslist }),
+      'and the later failure was recorded rather than swallowed'
+      or diag join "\n", map { $_->log // '' } @{ $job->_statuslist };
+};
+
+subtest 'loadmibs__vendor_report_is_an_lfs_stub__refuses_without_deleting' => sub {
+    my $job = run_loadmibs( mibhome_with_lfs_stubs(), 'cisco' );
+
+    is $job->status, 'error',
+      'the guard covers the single-vendor read as well'
+      or diag $job->log;
+
+    # The line count is the only thing that distinguishes this branch from the
+    # default one, so without it this subtest silently becomes a duplicate of
+    # the first: three lines is cisco_oids alone, twelve is all four files.
+    like $job->log, qr/\bread 3 lines\b/,
+      'and only the named vendor report was read'
+      or diag $job->log;
+
+    is_deeply [ grep { m/^(?:delete|populate) SNMPObject/ } @STATEMENTS ], [],
+      'and the load branch never touched snmp_object'
+      or diag join "\n", @STATEMENTS;
+};
+
+done_testing;


### PR DESCRIPTION
## What happens today

`netdisco-do loadmibs` deletes every row of `snmp_object` and repopulates it
from `$mibhome/EXTRAS/reports/*_oids`. There is no check that the parse produced
anything, so when the reports yield zero objects the table is emptied and the
job exits 0.

Reproduced on a live install (PostgreSQL 18.4, App::Netdisco 2.101000):

```
loadmibs - loaded 0 objects from netdisco-mibs
loadmibs - removed 597248 oids
loadmibs - added 0 new oids
loadmibs: status done
```

The SNMP object browser is empty afterwards and nothing reports a failure.

## Why the reports parse to nothing

From netdisco-mibs 4.054 onward, `EXTRAS/reports/*` is under a git-lfs filter,
and GitHub tag archives do not resolve LFS. The files are present but contain
pointer stubs:

```
$ head -1 $mibhome/EXTRAS/reports/cisco_oids
version https://git-lfs.github.com/spec/v1
```

Every file in that directory matches the one filter, so this is all-or-nothing
rather than a partial-content case. Worth noting that 4.053 is not affected:
it ships no `*_oids` files at all, so `read_lines` croaks and the job already
fails loudly. Only 4.054 and later are silent.

## What this changes

Two commits.

**`loadmibs: read each report file once`** removes a double read. The `*_oids`
glob already returns `rfc_oids`, `net-snmp_oids` and `cisco_oids`, which are
then read a second time from the hardcoded list. `%seenoid` was already deduping
the parse, so the loaded rows are unchanged; this only stops re-reading the
files, of which `cisco_oids` alone is 27 MB.

**`loadmibs: refuse to empty snmp_object when nothing was parsed`** adds the
guard. When the parse yields no objects the delete and repopulate are skipped,
the reason is logged at error level, and the job's status becomes `error`, which
`bin/netdisco-do` turns into exit 1.

The two blocks after the guard still run. They act on `device_browser`, not
`snmp_object`: snapshot promotion reads the table the refusal just preserved,
and the legacy snapshot upgrade is unrelated work that should not become
collateral damage. That is why the guard calls `add_status` and lets the worker
continue, rather than returning `Status->error` immediately.

## Deliberately not fixed here

Two other things in this file turned up while investigating. Both are
independent of this bug, so both are filed as their own issues rather than
widening this PR. They are mentioned here because they are useful context while
reading the same function.

1. **#1610, `LoadMIBs.pm:27-31` filters full paths, not basenames.** Both `grep`s run
   before `map { (splitdir($_))[-1] }`, so `! m/\./` rejects any path containing
   a dot: give the mibhome a dotted path and `@maps` empties and every vendor
   report is silently skipped. A release tarball unpacked as
   `netdisco-mibs-4.054/` hits this. The `! m/^(?:EXTRAS)$/` filter on the line
   above is dead for the same reason, since a full path can never equal
   `EXTRAS`. The guard still fires correctly on a stubbed tree, because the
   three hardcoded reports are stubs too, but a mixed tree could load partial
   data and pass.
2. **#1611, `netdisco-do loadmibs -e <vendor>` replaces the whole table** with one
   vendor's objects, because the read is scoped to that vendor but the delete is
   not. The guard covers the empty case on that path but not the partial one.

## Root cause, for context

This is a guard, not a fix for the underlying situation. `snmp_object` looks
like it is mid-migration out of the MIB reports and into
`upstream-sources/bootstrap/netdisco-mibs-snmp-object.sql` in netdisco-mibs
(commit `57498439`), but netdisco was never wired to fetch it. Happy to work on
the consumer side of that separately if it would help.

## Testing

New file `xt/31-loadmibs-guard.t`, four subtests, runs with no database like the
rest of `xt/`:

- reports are LFS stubs: the job errors, says why, logs at error level, reads
  each report once, and issues no `delete` or `populate` against `snmp_object`
- reports parse to objects: the guard does not fire and the table is replaced
- a block after the guard dies: the refusal is still the job's outcome, and the
  later failure is recorded rather than swallowed
- the single-vendor path with a stub report: the guard covers it too

Verified by mutation rather than by inspection. Removing the guard, inverting
it, dropping either half of the refusal, returning early instead of continuing,
and reverting the dedupe each cause a failure.

Two things about the test that are worth knowing before reading it. It defines a
stand-in schema and installs it over the plugin's imported `schema`, a pattern
nothing else in `xt/` uses; it is there because this worker calls the database
unconditionally and the rest of `xt/` has no such dependency. And it overrides
the Dancer logger to `capture`, because the guard logs at error level and a
clean run would otherwise print the refusal every time; `DANCER_DEBUG` restores
the console.

`bin/netdisco-deploy` and the process exit code have no automated coverage. Both
were verified by hand.

## Operator impact

Anyone whose `loadmibs` currently succeeds against netdisco-mibs 4.054 or later
starts getting exit 1 instead of a silently emptied table. That is the point,
but it will stop a `set -e` cron or CI step that has been quietly destroying
data, so it is worth a release note.

The one in-tree caller, `bin/netdisco-deploy:288`, discards `system()`'s return
and prints `done.` regardless, so it does not yet notice. That is sent
separately, since it stands on its own: `loadmibs` can already fail for other
reasons and none of them reach the operator today. Either PR can go in without
the other.

## Two offers

- The guard uses `$job->add_status` so the blocks below still run.
  `add_status` does not otherwise appear in a worker plugin, only in framework
  code. If you would rather it read like the other ~30 `Status->error` sites, I
  can move those two `DeviceBrowser` blocks into a second
  `register_worker({ phase => 'store' })` in the same file and have the guard
  return `Status->error` directly. Behaviour and exit code are identical either
  way, so I left it alone rather than restructure on a guess.
- I have not added a `Changes` entry, since the recent ones look like they land
  in their own commits rather than inside a feature PR. Say the word and I will
  add one under `[BUG FIXES]`.
