### PR TITLE
Scan Python as well as JavaScript in CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
One line: add `python` to the CodeQL language matrix.

The workflow has scanned only `javascript` since it was added, but the
repository also ships a Python package under `share/python/netdisco/`, 17
tracked `.py` files with their own `pyproject.toml`.

```
share/python/netdisco/netdisco/runner.py
share/python/netdisco/netdisco/util/ssh.py
share/python/netdisco/netdisco/util/database.py
share/python/netdisco/netdisco/util/config.py
...
```

No other change is needed. The matrix already runs one job per language, and
the existing permissions cover the added job. The comment on the following line
already lists `python` as supported.

## I ran it first, so this should not land you a backlog

I ran the same suite locally with the CodeQL CLI against this branch:

```
tool: CodeQL 2.26.2 (python-queries 1.8.7)
suite: codeql-suites/python-code-scanning.qls   (the default, as configured here)
CodeQL scanned 17 out of 17 Python files
rules run: 43
alerts: 0
errors or warnings during the run: 0
```

So merging this should add a green job rather than a triage queue.

To be precise about what that was: CodeQL CLI 2.26.2 running
`python-code-scanning.qls` over this checkout, zero alerts across the 17 `.py`
files. Your hosted run uses whichever bundle `github/codeql-action@v4.37.3`
pins, so a query added since 2.26.2 could in principle fire where mine did not.
