### PR TITLE
netdisco-deploy: report a loadmibs failure instead of printing done

### DIFF
--- a/bin/netdisco-deploy
+++ b/bin/netdisco-deploy
@@ -285,8 +285,13 @@ sub deploy_mibs {
 
     if (schema('netdisco')->resultset('SNMPObject')->count) {
       print 'Updating SNMP Browser... ';
-      system('netdisco-do loadmibs --quiet');
-      say 'done.';
+      if (system('netdisco-do loadmibs --quiet') == 0) {
+        say 'done.';
+      }
+      else {
+        print color 'bold red';
+        say 'SNMP Browser update failed!';
+      }
     }
   }
 


### PR DESCRIPTION
`deploy_mibs` runs `netdisco-do loadmibs --quiet` and discards the result:

```perl
system('netdisco-do loadmibs --quiet');
say 'done.';
```

`done.` prints whether the job succeeded or not, so any `loadmibs` failure
during a MIB update is invisible. `netdisco-do` already exits non-zero on a
failed job (`bin/netdisco-do:230` sets `$exitstatus = 1` when the job status is
not `done`, and `:234` exits with it), so the information is there and simply
not read.

This checks the return and prints a red failure line instead of `done.`. The
existing `print color 'reset'` at the end of `deploy_mibs` covers the new
branch, so no colour leaks.

Three lines of behaviour change, no new dependencies.

## Scope

This stands on its own and does not depend on any other change. `loadmibs` can
fail for several reasons today, including a missing or unreadable report file,
and none of them currently reach the operator running a MIB update.

It does become more useful alongside the `snmp_object` guard I have sent
separately, since that makes `loadmibs` exit non-zero in a case where it
currently exits 0 while emptying the table. But the two are independent and
either can go in without the other.
