### PR TITLE
Restrict Swagger UI to netdisco's own API definition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,10 @@ share/public/css/smoothness/jquery-ui.custom.min.css binary
 share/public/javascripts/jstree/jstree.min.js binary
 share/public/css/toastr.css binary
 share/public/css/*.min.css binary
-share/public/swagger-ui/* binary
+# Only the generated artifacts. index.html, oauth2-redirect.html and the
+# version marker are hand-readable, and marking them binary stops git diffing
+# and three-way merging them. The favicons need no entry: git detects binary
+# content on its own.
+share/public/swagger-ui/*.js binary
+share/public/swagger-ui/*.css binary
+share/public/swagger-ui/*.map binary

--- a/MANIFEST
+++ b/MANIFEST
@@ -698,6 +698,7 @@ xt/20-checkacl.t
 xt/21-check_acl_no_ipaddr_only.t
 xt/30-backend-workers.t
 xt/31-loadmibs-guard.t
+xt/32-swagger-ui-guard.t
 xt/html/portsort.html
 xt/js/qunit-tap.js
 xt/js/run_qunit.js

--- a/share/public/swagger-ui/index.html
+++ b/share/public/swagger-ui/index.html
@@ -40,9 +40,70 @@
     window.onload = function() {
       // https://github.com/justinebateman/swagger-ui-json-tree-plugin
       SwaggerUIStandalonePreset.unshift(jsonTreePlugin.default);
+
+      // Swagger UI 3.x merges the query string OVER the options passed below.
+      // Inside the bundle it is Object.assign({}, defaults, options, query), so
+      // a url set here cannot override ?url=, and ?config= is fetched and
+      // applied as remote configuration. Netdisco uses exactly one parameter,
+      // the ?url= that Web.pm builds with uri_for so it carries any path prefix,
+      // so the address is reduced to that before the bundle reads it.
+
+      // Compare origins rather than matching the string. Pattern matching is not
+      // sufficient: for http and https the URL parser treats a backslash as a
+      // path separator, so "/\evil.com/x.json" looks relative and resolves to
+      // another origin. The path is pinned as well, because same origin alone
+      // would accept any JSON an attacker could get served from this host.
+      // Web.pm only ever builds uri_for('/swagger.json'), and a path-prefixed
+      // deployment still ends in it.
+      function isOwnSpecUrl(candidate) {
+        if (!candidate) return false;
+        var resolved;
+        try { resolved = new URL(candidate, window.location.href); }
+        catch (e) { return false; }
+        return resolved.origin === window.location.origin
+          && /\/swagger\.json$/.test(resolved.pathname);
+      }
+
+      // The query reduced to a url= that validates, or "". Read without
+      // URLSearchParams: a browser that has const but not that constructor would
+      // throw and render no page at all, where falling through to the default
+      // degrades safely. The matched pair is kept raw rather than re-encoded, so
+      // the address stays byte-identical to the link Web.pm builds and no
+      // encoding round trip can alter a legitimate path. A duplicated url=
+      // cannot bypass this: whichever pair validates, exactly one is emitted, so
+      // the bundle's own parser has no second value to prefer.
+      function canonicalSearch() {
+        var pairs = window.location.search.replace(/^\?/, '').split('&');
+        for (var i = 0; i < pairs.length; i++) {
+          if (pairs[i].indexOf('url=') !== 0) continue;
+          if (isOwnSpecUrl(decodeURIComponent(pairs[i].slice(4).replace(/\+/g, ' '))))
+            return '?' + pairs[i];
+        }
+        return '';
+      }
+
+      // This rewrite is what removes ?config=, ?configUrl= and a rejected ?url=,
+      // because the bundle reads window.location.search at construction time.
+      // The hash is preserved: deepLinking uses it.
+      var clean = canonicalSearch();
+      if (clean !== window.location.search) {
+        var address = window.location.pathname + clean + window.location.hash;
+        if (window.history && window.history.replaceState) {
+          window.history.replaceState(null, '', address);
+        }
+        else {
+          // Without replaceState the address cannot be corrected in place, so
+          // reload to the clean one. Construction MUST NOT run first: the
+          // poisoned query is still live until the reload lands. A clean query
+          // canonicalizes to itself, so this cannot loop.
+          window.location.replace(address);
+          return;
+        }
+      }
+
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "https://petstore.swagger.io/v2/swagger.json",
+        url: "../swagger.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [
@@ -55,7 +116,13 @@
         layout: "StandaloneLayout",
         apisSorter: "alpha",
         operationsSorter: "alpha",
-        docExpansion: "none"
+        docExpansion: "none",
+        // The online validator badge is on by default and sends the definition
+        // URL to a Swagger-hosted service on every page load, which for most
+        // deployments means publishing an internal hostname. It cannot be seen in
+        // local testing: the badge suppresses itself when the URL contains
+        // localhost or 127.0.0.1.
+        validatorUrl: null
       })
       // End Swagger UI call region
 

--- a/xt/32-swagger-ui-guard.t
+++ b/xt/32-swagger-ui-guard.t
@@ -1,0 +1,101 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use File::Spec::Functions qw/catfile updir/;
+use FindBin;
+
+# This file asserts the CONTENT of the shipped Swagger UI page, not its
+# behaviour, and the distinction matters when reading a pass.
+#
+# The failure it guards is a re-vendor: dropping in a fresh upstream index.html
+# reverts every local change below at once and silently, which is exactly how the
+# petstore default arrived in the first place. A content assertion catches that.
+#
+# It cannot prove the page is safe, because it shares its input with the code it
+# checks. The behavioural evidence is a browser driven against the page with
+# off-host requests blocked and recorded, and it does not live in this suite,
+# because the distribution has no working JavaScript test path.
+
+my $page = catfile( $FindBin::Bin, updir(),
+    'share', 'public', 'swagger-ui', 'index.html' );
+
+my $html = do {
+    open my $fh, '<', $page or die "cannot read $page: $!";
+    local $/;
+    <$fh>;
+};
+
+subtest 'swagger_ui_index__shipped_page__names_no_external_spec_host' => sub {
+    unlike $html, qr{https?://[^"'\s]*\bswagger\.io}i,
+        'no swagger.io host appears anywhere in the page';
+};
+
+subtest 'swagger_ui_index__shipped_page__defaults_to_own_swagger_json' => sub {
+    # Relative, so it resolves under a path-prefixed deployment and from both
+    # /swagger-ui/ and /swagger-ui/index.html.
+    like $html, qr{\burl:\s*["']\.\./swagger\.json["']},
+        'the default spec URL is ../swagger.json';
+};
+
+subtest 'swagger_ui_index__shipped_page__disables_the_online_validator' => sub {
+    # On by default, and it sends the definition URL to a Swagger-hosted service
+    # on every page load, which for most deployments publishes an internal
+    # hostname. It cannot be caught in local testing: the badge suppresses itself
+    # when the URL contains localhost or 127.0.0.1.
+    like $html, qr{\bvalidatorUrl:\s*null\b},
+        'validatorUrl is null';
+};
+
+subtest 'swagger_ui_index__shipped_page__gates_the_query_before_construction' => sub {
+    # Ordering is the whole mechanism, not an incidental detail. The bundle reads
+    # window.location.search when SwaggerUIBundle runs, so a gate placed after
+    # that call cannot remove anything: the request has already left.
+    # Anchored on the CALL, not the bare identifier. The page's comments name
+    # replaceState too, and an earlier version of this test matched one of them,
+    # so deleting the real call left it passing.
+    my $gate      = $html =~ m{history\.replaceState\(} ? $-[0] : -1;
+    my $construct = index $html, 'SwaggerUIBundle({';
+
+    cmp_ok $gate,      '>', -1, 'the address is rewritten somewhere in the page';
+    cmp_ok $construct, '>', -1, 'the bundle is constructed somewhere in the page';
+    cmp_ok $gate, '<', $construct,
+        'the rewrite runs before the bundle reads the query';
+
+    # Where replaceState is unavailable the page reloads to the clean address
+    # instead, and it MUST NOT fall through to construction: the poisoned query
+    # is still live until the reload lands. That return is the whole safety of
+    # the fallback path, so the text between the two is checked for it.
+    my $fallback = $html =~ m{location\.replace\(} ? $-[0] : -1;
+    cmp_ok $fallback, '>', -1, 'a reload fallback exists for missing replaceState';
+    cmp_ok $fallback, '<', $construct, 'the fallback also precedes construction';
+    like substr($html, $fallback, $construct - $fallback), qr{\breturn\b},
+        'the fallback returns rather than falling through to construction';
+
+    # Either polarity, because an early return and a combined boolean are both
+    # correct and pinning one would fail a rewrite that is not a regression. What
+    # is asserted is that origins are COMPARED at all. Whether the comparison
+    # runs the right way round is not a question a grep can answer, and is
+    # settled by driving the page instead.
+    like $html, qr{\.origin\s*[!=]==\s*window\.location\.origin},
+        'the candidate is judged by comparing origins';
+    # Matches the literal JavaScript /\/swagger\.json$/ , so the backslash and
+    # the dollar are both escaped for Perl rather than anchoring this pattern.
+    like $html, qr{swagger\\\.json\$/},
+        'the accepted path is pinned to swagger.json';
+};
+
+subtest 'swagger_ui_index__shipped_page__reads_the_parameter_without_URLSearchParams' => sub {
+    # Passes before the fix as well as after, deliberately: it guards a choice a
+    # later editor would naturally "tidy" into URLSearchParams. A browser lacking
+    # that constructor would then throw here and render no page at all, where
+    # falling through to the default degrades safely.
+    # The construction, not the bare name: the page's own comment explains what
+    # it avoids and why, and naming the identifier there is worth keeping.
+    unlike $html, qr{new\s+URLSearchParams},
+        'the query is parsed without constructing URLSearchParams';
+};
+
+done_testing;


### PR DESCRIPTION
Standalone fix for the bundled Swagger UI page, against 2.102000. Independent of
#1615.

The page now takes its API definition from netdisco only:

- defaults to `../swagger.json`
- accepts `?url=` only when it resolves to this origin and a `/swagger.json`
  path, so the existing `/swagger-ui` redirect still works
- drops every other query parameter, `?config=` and `?configUrl=` included,
  before the bundle reads it
- sets `validatorUrl: null`, so nothing is sent to the Swagger validator on load

The first commit narrows a `.gitattributes` rule that marked all of
`swagger-ui/` binary, so `index.html` diffs rather than showing as a byte count.

`xt/32-swagger-ui-guard.t` catches a future re-vendor reverting this. I also drove
the page with off-host requests blocked: each case above loads netdisco's own
definition and makes no external request.
