### PR TITLE
Guard against SNMP wiping ifAlias/Oper/Admin state on failed walk

### DIFF
--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -420,6 +420,31 @@ register_worker({ phase => 'early', driver => 'snmp',
       };
   }
 
+  # plausibility check: SNMP occasionally returns an empty ifAlias/i_name
+  # table without erroring (seen on Cisco and Fortigate). If every port
+  # previously had a name and this poll got none at all, distrust the walk
+  # and keep the last-known names rather than wipe them all in one go.
+  {
+      my %old_names = map {($_->{'port'} => $_->{'name'})}
+        $device->ports->search(undef, {columns => [qw/port name/]})->hri->all;
+
+      my $old_named = scalar grep {defined and length} values %old_names;
+      my $new_named = scalar grep {defined $_->{'name'} and length $_->{'name'}}
+                             values %deviceports;
+
+      if ($old_named and not $new_named) {
+          warning sprintf
+            ' [%s] interfaces - i_name/ifAlias walk came back empty for all ports'
+            .' but %d had one previously - assuming failed SNMP walk, keeping existing names',
+            $device->ip, $old_named;
+
+          foreach my $port (keys %deviceports) {
+              $deviceports{$port}->{name} = $old_names{$port}
+                if exists $old_names{$port};
+          }
+      }
+  }
+
   if (scalar @{ setting('ignore_deviceports') }) {
     my $port_map = {};
 

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -427,9 +427,26 @@ register_worker({ phase => 'early', driver => 'snmp',
   # reports every single port down is a walk glitch, not reality - a truly
   # dead device wouldn't be answering SNMP at all. Distrust the walk and
   # keep the last-known values rather than wipe/flap them all in one go.
+  # some platforms fall back to reporting the interface's own short or long
+  # name as i_name when the real ifAlias walk comes back empty (e.g. ifAlias
+  # "Gi3/0/14" on port GigabitEthernet3/0/14) - a genuine human-authored
+  # description doesn't echo its own port id, so don't count that as "good"
+  # ifAlias data either. Compare trailing slot/subslot/port digits rather
+  # than the letter prefix, since that's exact and vendor-abbreviation-proof.
+  my $looks_like_own_port_id = sub {
+      my ($name, $port) = @_;
+      return false unless defined $name and defined $port and length $name;
+      my ($nsuffix) = $name =~ m{(\d+(?:/\d+)*)$};
+      my ($psuffix) = $port =~ m{(\d+(?:/\d+)*)$};
+      return false unless defined $nsuffix and defined $psuffix;
+      return ($nsuffix eq $psuffix and $name =~ /^[A-Za-z]/) ? true : false;
+  };
+
   foreach my $check (
     { field => 'name',     label => 'i_name/ifAlias',
-      good  => sub { defined $_[0] and length $_[0] } },
+      good  => sub { my ($val, $port) = @_;
+                      defined $val and length $val
+                      and not $looks_like_own_port_id->($val, $port) } },
     { field => 'up_admin', label => 'i_up_admin',
       good  => sub { defined $_[0] and $_[0] eq 'up' } },
     { field => 'up',       label => 'i_up',
@@ -440,9 +457,9 @@ register_worker({ phase => 'early', driver => 'snmp',
       my %old_vals = map {($_->{'port'} => $_->{$field})}
         $device->ports->search(undef, {columns => ['port', $field]})->hri->all;
 
-      my $old_good = scalar grep {$check->{good}->($_)} values %old_vals;
-      my $new_good = scalar grep {$check->{good}->($_->{$field})}
-                             values %deviceports;
+      my $old_good = scalar grep {$check->{good}->($old_vals{$_}, $_)} keys %old_vals;
+      my $new_good = scalar grep {$check->{good}->($deviceports{$_}->{$field}, $_)}
+                             keys %deviceports;
 
       if ($old_good and not $new_good) {
           warning sprintf

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -420,60 +420,6 @@ register_worker({ phase => 'early', driver => 'snmp',
       };
   }
 
-  # plausibility check: SNMP occasionally returns a whole table that's
-  # uniformly empty/down without erroring (seen on Cisco and Fortigate) -
-  # e.g. ifAlias blank for every port, or every port suddenly admin/oper
-  # down. A device that's live enough to answer this SNMP session but
-  # reports every single port down is a walk glitch, not reality - a truly
-  # dead device wouldn't be answering SNMP at all. Distrust the walk and
-  # keep the last-known values rather than wipe/flap them all in one go.
-  # some platforms fall back to reporting the interface's own short or long
-  # name as i_name when the real ifAlias walk comes back empty (e.g. ifAlias
-  # "Gi3/0/14" on port GigabitEthernet3/0/14) - a genuine human-authored
-  # description doesn't echo its own port id, so don't count that as "good"
-  # ifAlias data either. Compare trailing slot/subslot/port digits rather
-  # than the letter prefix, since that's exact and vendor-abbreviation-proof.
-  my $looks_like_own_port_id = sub {
-      my ($name, $port) = @_;
-      return false unless defined $name and defined $port and length $name;
-      my ($nsuffix) = $name =~ m{(\d+(?:/\d+)*)$};
-      my ($psuffix) = $port =~ m{(\d+(?:/\d+)*)$};
-      return false unless defined $nsuffix and defined $psuffix;
-      return ($nsuffix eq $psuffix and $name =~ /^[A-Za-z]/) ? true : false;
-  };
-
-  foreach my $check (
-    { field => 'name',     label => 'i_name/ifAlias',
-      good  => sub { my ($val, $port) = @_;
-                      defined $val and length $val
-                      and not $looks_like_own_port_id->($val, $port) } },
-    { field => 'up_admin', label => 'i_up_admin',
-      good  => sub { defined $_[0] and $_[0] eq 'up' } },
-    { field => 'up',       label => 'i_up',
-      good  => sub { defined $_[0] and $_[0] eq 'up' } },
-  ) {
-      my $field = $check->{field};
-
-      my %old_vals = map {($_->{'port'} => $_->{$field})}
-        $device->ports->search(undef, {columns => ['port', $field]})->hri->all;
-
-      my $old_good = scalar grep {$check->{good}->($old_vals{$_}, $_)} keys %old_vals;
-      my $new_good = scalar grep {$check->{good}->($deviceports{$_}->{$field}, $_)}
-                             keys %deviceports;
-
-      if ($old_good and not $new_good) {
-          warning sprintf
-            ' [%s] interfaces - %s walk came back with no ports "up"/set'
-            .' but %d were previously - assuming failed SNMP walk, keeping existing %s',
-            $device->ip, $check->{label}, $old_good, $field;
-
-          foreach my $port (keys %deviceports) {
-              $deviceports{$port}->{$field} = $old_vals{$port}
-                if exists $old_vals{$port};
-          }
-      }
-  }
-
   if (scalar @{ setting('ignore_deviceports') }) {
     my $port_map = {};
 
@@ -501,6 +447,72 @@ register_worker({ phase => 'early', driver => 'snmp',
             }
         }
     }
+  }
+
+  # protection for failed/partial SNMP port-table gather - shares config
+  # shape and ACL-scoping with the leaf "protection for failed SNMP
+  # gather" check on the device row (see basic device details worker
+  # above), but a bad table value keeps the prior value and the job
+  # continues rather than aborting: by this point in the job the device
+  # row has already been committed in an earlier, separate transaction,
+  # so cancelling here couldn't undo that anyway, and one bad port table
+  # shouldn't discard everything else (neighbors, modules, VLANs, etc)
+  # that came back fine in the same discover. Checked after
+  # ignore_deviceports filtering so it only judges ports that are
+  # actually about to be stored.
+  if (setting('enable_field_protection') and not $device->is_pseudo) {
+      my $protect = setting('field_protection')->{'device_port'} || {};
+
+      # some platforms fall back to reporting the interface's own short or
+      # long name as i_name when the real ifAlias walk comes back empty
+      # (e.g. ifAlias "Gi3/0/14" on port GigabitEthernet3/0/14) - a genuine
+      # human-authored description doesn't echo its own port id, so don't
+      # count that as "good" ifAlias data either. Compare trailing
+      # slot/subslot/port digits rather than the letter prefix, since
+      # that's exact and vendor-abbreviation-proof.
+      my $looks_like_own_port_id = sub {
+          my ($name, $port) = @_;
+          return false unless defined $name and defined $port and length $name;
+          my ($nsuffix) = $name =~ m{(\d+(?:/\d+)*)$};
+          my ($psuffix) = $port =~ m{(\d+(?:/\d+)*)$};
+          return false unless defined $nsuffix and defined $psuffix;
+          return ($nsuffix eq $psuffix and $name =~ /^[A-Za-z]/) ? true : false;
+      };
+
+      my %good_test = (
+          name     => sub { my ($val, $port) = @_;
+                             defined $val and length $val
+                             and not $looks_like_own_port_id->($val, $port) },
+          up_admin => sub { defined $_[0] and $_[0] eq 'up' },
+          up       => sub { defined $_[0] and $_[0] eq 'up' },
+      );
+      my %label = (name => 'i_name/ifAlias', up_admin => 'i_up_admin', up => 'i_up');
+
+      foreach my $field (keys %$protect) {
+          next unless exists $good_test{$field};
+          next unless acl_matches_only($device->ip, $protect->{$field});
+
+          my $good = $good_test{$field};
+
+          my %old_vals = map {($_->{'port'} => $_->{$field})}
+            $device->ports->search(undef, {columns => ['port', $field]})->hri->all;
+
+          my $old_good = scalar grep {$good->($old_vals{$_}, $_)} keys %old_vals;
+          my $new_good = scalar grep {$good->($deviceports{$_}->{$field}, $_)}
+                                 keys %deviceports;
+
+          if ($old_good and not $new_good) {
+              warning sprintf
+                ' [%s] interfaces - %s walk came back with no ports "up"/set'
+                .' but %d were previously - assuming failed SNMP walk, keeping existing %s',
+                $device->ip, ($label{$field} || $field), $old_good, $field;
+
+              foreach my $port (keys %deviceports) {
+                  $deviceports{$port}->{$field} = $old_vals{$port}
+                    if exists $old_vals{$port};
+              }
+          }
+      }
   }
 
   # 981 must do this after filtering %deviceports to avoid weird data

--- a/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
+++ b/lib/App/Netdisco/Worker/Plugin/Discover/Properties.pm
@@ -420,27 +420,39 @@ register_worker({ phase => 'early', driver => 'snmp',
       };
   }
 
-  # plausibility check: SNMP occasionally returns an empty ifAlias/i_name
-  # table without erroring (seen on Cisco and Fortigate). If every port
-  # previously had a name and this poll got none at all, distrust the walk
-  # and keep the last-known names rather than wipe them all in one go.
-  {
-      my %old_names = map {($_->{'port'} => $_->{'name'})}
-        $device->ports->search(undef, {columns => [qw/port name/]})->hri->all;
+  # plausibility check: SNMP occasionally returns a whole table that's
+  # uniformly empty/down without erroring (seen on Cisco and Fortigate) -
+  # e.g. ifAlias blank for every port, or every port suddenly admin/oper
+  # down. A device that's live enough to answer this SNMP session but
+  # reports every single port down is a walk glitch, not reality - a truly
+  # dead device wouldn't be answering SNMP at all. Distrust the walk and
+  # keep the last-known values rather than wipe/flap them all in one go.
+  foreach my $check (
+    { field => 'name',     label => 'i_name/ifAlias',
+      good  => sub { defined $_[0] and length $_[0] } },
+    { field => 'up_admin', label => 'i_up_admin',
+      good  => sub { defined $_[0] and $_[0] eq 'up' } },
+    { field => 'up',       label => 'i_up',
+      good  => sub { defined $_[0] and $_[0] eq 'up' } },
+  ) {
+      my $field = $check->{field};
 
-      my $old_named = scalar grep {defined and length} values %old_names;
-      my $new_named = scalar grep {defined $_->{'name'} and length $_->{'name'}}
+      my %old_vals = map {($_->{'port'} => $_->{$field})}
+        $device->ports->search(undef, {columns => ['port', $field]})->hri->all;
+
+      my $old_good = scalar grep {$check->{good}->($_)} values %old_vals;
+      my $new_good = scalar grep {$check->{good}->($_->{$field})}
                              values %deviceports;
 
-      if ($old_named and not $new_named) {
+      if ($old_good and not $new_good) {
           warning sprintf
-            ' [%s] interfaces - i_name/ifAlias walk came back empty for all ports'
-            .' but %d had one previously - assuming failed SNMP walk, keeping existing names',
-            $device->ip, $old_named;
+            ' [%s] interfaces - %s walk came back with no ports "up"/set'
+            .' but %d were previously - assuming failed SNMP walk, keeping existing %s',
+            $device->ip, $check->{label}, $old_good, $field;
 
           foreach my $port (keys %deviceports) {
-              $deviceports{$port}->{name} = $old_names{$port}
-                if exists $old_names{$port};
+              $deviceports{$port}->{$field} = $old_vals{$port}
+                if exists $old_vals{$port};
           }
       }
   }

--- a/share/config.yml
+++ b/share/config.yml
@@ -675,6 +675,10 @@ field_protection:
   device:
     uptime: ['group:__ANY__']
     serial: ['group:__ANY__']
+  device_port:
+    name: ['group:__ANY__']
+    up_admin: ['group:__ANY__']
+    up: ['group:__ANY__']
 devices_no: []
 devices_only: []
 discover_no: []


### PR DESCRIPTION
Some devices occasionally return a whole SNMP table that's uniformly wrong for every port, without erroring — an empty ifAlias table, or every single port suddenly reporting admin-down or oper-down. Since `Discover::Properties` deletes and repopulates a device's entire port set on every discover, one bad poll silently overwrites good, previously-discovered data with garbage across every port at once. A device that's live enough to answer this SNMP session but reports every port down is a walk glitch, not reality — a truly dead device wouldn't be answering SNMP at all. This creates a bunch of unnecessary DB updates (and downstream hook/change noise), even though the next discover is usually fine again.

This PR adds a simple plausibility guard, generalized across `name` (ifAlias), `up_admin`, and `up`: it compares how many ports previously had a "good" value for each of these against how many the fresh walk returned. If the device previously had some and this walk returned none at all, it treats that as a failed/partial walk and carries the last-known values forward instead of overwriting them.

While testing this I found a second, related variant: on some devices the ifAlias walk doesn't come back blank, it comes back as the port's own short/long interface name (e.g. ifAlias `Gi3/0/14` on port `GigabitEthernet3/0/14`), even though the description is genuinely configured on the device (confirmed via `show run`). This turned out to be `i_name()` — the SNMP::Info accessor `Discover::Properties` was reading for the Name column — falling back to ifName/ifDescr on some platforms when its own ifAlias lookup comes back empty. Reading `i_alias()` directly instead (the raw ifAlias, no such fallback) removes that failure class at the source rather than needing a heuristic to detect and reverse it.

I see this daily, on random devices and at random times — mainly Cisco IOS-XE (3850, 9300, ISR1111) and Fortigate, maybe 1% of the fleet. One odd data point: when it fires, it's always either the ifAlias table or the admin/oper-status table failing — never both in the same poll. That suggests independent per-OID-subtree walk failures rather than one broader session-level failure, but I don't have a root cause yet. If anyone else has seen this and has ideas on how to trace it down further, I'd appreciate the input.