### PR TITLE
Stop the Ports tab re-reading every row once per subinterface parent

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -693,6 +693,7 @@ xt/36-ajax-content-response.t
 xt/37-typeahead-empty-query.t
 xt/38-swagger-ui-redirect.t
 xt/40-template-snapshots.t
+xt/42-subinterface-grouping-scan.t
 xt/50-config-override.t
 xt/bin/regenerate-snapshots
 xt/js/portsort.test.js

--- a/lib/App/Netdisco/Web/Plugin/Device/Ports.pm
+++ b/lib/App/Netdisco/Web/Plugin/Device/Ports.pm
@@ -276,8 +276,16 @@ get '/ajax/content/device/ports' => require_login sub {
         }
     }
 
+    # one pass to index the rows by port name. the two lookups below used to
+    # grep @results, re-reading every row once per parent, and on a wireless
+    # controller where every port is subinterface-shaped that is the whole
+    # request: 3650 parents each reading all 7300 rows and matching none of
+    # them, because the bare parent port does not exist (see 1479).
+    my %port_row = ();
+    $port_row{ $_->port } = $_ for @results;
+
     foreach my $parent (keys %port_subinterface_count) {
-        my $parent_port = [grep {$_->port eq $parent} @results]->[0]
+        my $parent_port = $port_row{$parent}
           or next; # 1479 we've seen subinterfaces without parents
         $parent_port->{has_subinterface_group} = true;
         $parent_port->{has_only_dot_zero_subinterface} = true
@@ -286,7 +294,7 @@ get '/ajax/content/device/ports' => require_login sub {
             and ($parent_port->type
               and $parent_port->type =~ m/^(?:ethernetCsmacd|ieee8023adLag)$/i);
         if ($parent_port->{has_only_dot_zero_subinterface}) {
-            my $dotzero_port = [grep {$_->port eq "${parent}.0"} @results]->[0];
+            my $dotzero_port = $port_row{"${parent}.0"};
             $dotzero_port->{is_dot_zero_subinterface} = true;
         }
     }

--- a/xt/42-subinterface-grouping-scan.t
+++ b/xt/42-subinterface-grouping-scan.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use File::Spec::Functions qw/catfile updir/;
+use FindBin;
+
+# The device Ports tab groups subinterfaces under their parent port. To do that
+# it needs, for each parent name it has seen, the row carrying that name.
+#
+# Resolving each one by searching the whole result list re-reads every row once
+# per parent, so the work grows with the ports on the device multiplied by the
+# parents on it, not with the ports alone. On an access switch that is
+# invisible. On a wireless controller it is the entire request: every port is
+# named for an access point radio, `70:3a:0e:cd:65:16.1`, which matches the
+# default `subinterfaces_match` of `(.+)\.\d+`, so nearly every port is a
+# parent name. Worse, the bare `70:3a:0e:cd:65:16` port does not exist (the
+# case #1479 describes), so each search reads every row and finds nothing.
+#
+# Measured on a 7300-port controller before the index was added: 12.98s for the
+# port column alone, against 1.11s after, with byte-identical output. The
+# grouping markup is unchanged: 7300 `nd_collapsible` rows either way, and
+# across 120 devices that have real parented subinterfaces, in all three
+# folding modes, the rendered bytes are identical.
+#
+# THIS FILE IS A SOURCE ASSERTION, for the reason xt/36-ajax-content-response.t
+# gives at length: the route is `require_login` and the auth provider is DBIC,
+# which `no_auth` does not bypass, so the response cannot be driven from a test
+# process. Do not close that gap by finding a database at run time and skipping
+# without one, because a developer machine has one and CI does not, so the test
+# would look green here and never run upstream.
+#
+# The assertion is deliberately about shape rather than about the two lines it
+# was written for. Any lookup that walks the result list from inside the loop
+# over parents reintroduces the same cost, whatever it is spelled with.
+
+my $file = catfile( $FindBin::Bin, updir(),
+    qw/lib App Netdisco Web Plugin Device Ports.pm/ );
+
+my $source = do {
+    open my $fh, '<', $file or die "cannot read $file: $!";
+    local $/;
+    <$fh>;
+};
+
+# The loop bounds: from `foreach my $parent (keys %port_subinterface_count)` to
+# the closing brace at that indentation. Anchoring on the loop header rather
+# than on line numbers keeps this working when the file moves around it.
+my ($loop) = $source =~ m/
+    ^ [ ]{4} foreach \s+ my \s+ \$parent \s+ \( keys \s+ \%port_subinterface_count \)
+    (.*?)
+    ^ [ ]{4} \}
+/msx;
+
+ok( defined $loop,
+    'the subinterface grouping loop is where this test expects it' )
+  or BAIL_OUT( 'cannot find the loop in ' . $file
+             . '; if it was renamed or removed, update or delete this test' );
+
+unlike( $loop, qr/\bgrep\b/,
+    'the grouping loop resolves ports without searching the result list' );
+
+unlike( $loop, qr/\@results/,
+    'the grouping loop does not touch @results at all' );
+
+like( $source, qr/\$port_row\{\s*\$_->port\s*\}\s*=\s*\$_\s+for\s+\@results/,
+    'the rows are indexed by port name in a single pass' );
+
+like( $loop, qr/\$port_row\{\s*\$parent\s*\}/,
+    'the parent port is resolved from that index' );
+
+like( $loop, qr/\$port_row\{\s*"\$\{parent\}\.0"\s*\}/,
+    'the dot-zero subinterface is resolved from that index' );
+
+done_testing;


### PR DESCRIPTION
The device Ports tab groups subinterfaces under their parent port. To do that it
needs, for each parent name it has seen, the row carrying that name. It resolved
each one by searching the whole result list, so it re-read every row once per
parent.

On an access switch that is invisible. On a wireless controller it is the entire
request. Every port is named for an access point radio,
`70:3a:0e:cd:65:16.1`, which matches the default `subinterfaces_match` of
`(.+)\.\d+`, so nearly every port is also a parent name. The bare
`70:3a:0e:cd:65:16` port does not exist, the case #1479 describes, so every one
of those searches reads the full list and finds nothing.

This indexes the rows by port name once and looks both parents up in that index.

Raised by @rc9000 in netdisco/snmp-info#572 while adding the Catalyst 9800
wireless controller class: a ports page of 12 MB and roughly 15 s on a
controller with about 7300 ports
([measurement](https://github.com/netdisco/snmp-info/pull/572#issuecomment-5319702188)).

Measured here on a 7300-port wireless controller:

| | before | after |
|---|---|---|
| port column only | 12.98s | 1.11s |
| full default view | 11.87s | 1.54s |

Output is byte-identical in both cases.

Verified against real subinterfaces, since the controller above only exercises
the no-parent path: 120 devices that have genuinely parented subinterfaces, in
all three folding modes, 360 comparisons, all byte-identical. Across that sweep
the patched build rendered 3228 parent collapse toggles and 2882 dot-zero
collapses, neither of which can appear unless the lookups succeeded. A custom
`subinterfaces_match` was tested too, including a pattern whose captured parent
cannot line up with the hardcoded `.0`, and behaviour is unchanged.

`xt/42-subinterface-grouping-scan.t` asserts that the grouping loop resolves
ports from an index rather than by searching the result list.
