### PR TITLE
Destroy a pane's autocomplete widgets before emptying it

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -84,6 +84,20 @@ jobs:
       - name: The map is posted once per settle and once per drag
         run: node --test xt/js/netmap-autosave.test.js
 
+  autocomplete-teardown:
+    name: autocomplete teardown on swap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      # Same naming rule as the jobs above: name the file, never a glob.
+      - name: A pane's autocomplete widgets are destroyed before it is emptied
+        run: node --test xt/js/autocomplete-teardown.test.js
+
   deferred-nodes:
     name: deferred node list recovery
     runs-on: ubuntu-latest

--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+2.108002 - tbd
+
+  [BUG FIXES]
+
+  * the Admin Topology and ACL editor pages, and a device's SNMP tab, no longer
+    use a little more of the browser's memory every time their results are
+    reloaded. left open and reloaded many times, they could slow down
+
 2.108001 - 2026-09-06
 
   [ENHANCEMENTS]

--- a/MANIFEST
+++ b/MANIFEST
@@ -719,6 +719,7 @@ xt/57-route-cache-ajax.t
 xt/58-behind-proxy-address.t
 xt/bin/regenerate-portsort-corpus
 xt/bin/regenerate-snapshots
+xt/js/autocomplete-teardown.test.js
 xt/js/deferred-nodes.test.js
 xt/js/netmap-autosave.test.js
 xt/js/netmap-legend.test.js

--- a/share/public/javascripts/netdisco.js
+++ b/share/public/javascripts/netdisco.js
@@ -188,6 +188,21 @@ function hideWithTooltip(target) {
   elements.hide();
 }
 
+// The widget puts its suggestion list and its live region on document.body, and
+// only its own destroy takes them down. That runs from jQuery's removal path,
+// which a pane emptied natively never reaches, so both outlive the field.
+//
+// Matching the class the widget adds, rather than netdisco's own selectors,
+// covers a field a site-local template introduced. Asking for the instance is
+// the guard: every other method name throws on an element it never took over.
+function destroyAutocompletesIn(pane) {
+  if (!pane) return;
+  pane.querySelectorAll('.ui-autocomplete-input').forEach(function (field) {
+    var widget = $(field).autocomplete('instance');
+    if (widget) { widget.destroy(); }
+  });
+}
+
 // A pointer click focuses the category, which :focus-within then holds open
 // after the pointer has left. detail is 0 for a keyboard-generated click, which
 // must not close what it just opened.
@@ -554,6 +569,7 @@ $(document).ready(function() {
       window.graph.fg._destructor();
     }
 
+    destroyAutocompletesIn(target);
     target.innerHTML = '';
   });
   document.body.addEventListener('htmx:responseError', function (evt) {

--- a/xt/js/autocomplete-teardown.test.js
+++ b/xt/js/autocomplete-teardown.test.js
@@ -1,0 +1,153 @@
+// Guards destroyAutocompletesIn and its call from the handler that empties a
+// pane.
+//
+// Not a source text test, deliberately. Both things that matter are about what
+// runs: every widget in the outgoing pane has to be reached, and it has to
+// happen before the empty, after which the fields are gone and their instances
+// cannot be found. So the shipped function and the shipped listener are
+// extracted and executed against stubs rather than read.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const source = fs.readFileSync(
+  path.join(ROOT, 'share', 'public', 'javascripts', 'netdisco.js'), 'utf8');
+
+// Take the shipped function text rather than a copy of it, so this cannot pass
+// against a helper that no longer says what the copy said.
+function braceMatch(from) {
+  let depth = 0;
+  for (let j = source.indexOf('{', from); j < source.length; j += 1) {
+    if (source[j] === '{') depth += 1;
+    if (source[j] === '}') { depth -= 1; if (depth === 0) return source.slice(from, j + 1); }
+  }
+  throw new Error('unbalanced braces from offset ' + from);
+}
+
+function extract(name) {
+  const from = source.search(new RegExp('function\\s+' + name + '\\s*\\('));
+  assert.notStrictEqual(from, -1, name + ' is not defined in netdisco.js');
+  return braceMatch(from);
+}
+
+// The listener is anonymous, so the event name is the only anchor.
+function extractListener(event) {
+  const anchor = source.indexOf("document.body.addEventListener('" + event + "'");
+  assert.notStrictEqual(anchor, -1, 'no listener for ' + event + ' in netdisco.js');
+  const from = source.indexOf('function', anchor);
+  return braceMatch(from);
+}
+
+// --- stubs -----------------------------------------------------------------
+
+// A field the widget never took over answers undefined to 'instance', and
+// throws for every other method name.
+function field(name, initialized, calls) {
+  return { name: name,
+           __widget: initialized
+             ? { destroy: function () { calls.push('destroy:' + name) } }
+             : undefined };
+}
+
+function pane(id, fields, calls) {
+  return {
+    id: id,
+    querySelectorAll: function (selector) {
+      calls.push('query:' + selector);
+      return fields;
+    },
+    set innerHTML(value) { calls.push('innerHTML=' + JSON.stringify(value)) },
+    get innerHTML() { return '' },
+  };
+}
+
+function jquery() {
+  return function (element) {
+    return { autocomplete: function (method) {
+      assert.strictEqual(method, 'instance',
+        'any other method name throws on a field that was never initialized');
+      return element.__widget;
+    } };
+  };
+}
+
+function teardown() {
+  return new Function('$', extract('destroyAutocompletesIn')
+    + '; return destroyAutocompletesIn;')(jquery());
+}
+
+function beforeRequest() {
+  return new Function('window', '$',
+    extract('destroyAutocompletesIn')
+    + '; return ' + extractListener('htmx:beforeRequest') + ';')({}, jquery());
+}
+
+// --- the helper ------------------------------------------------------------
+
+test('destroyAutocompletesIn__the_pane_holds_initialized_fields__destroys_every_one', () => {
+  const calls = [];
+  const fields = [field('dev1', true, calls), field('port1', true, calls),
+                  field('dev2', true, calls), field('port2', true, calls)];
+  teardown()(pane('topology_pane', fields, calls));
+  assert.deepStrictEqual(calls.filter((c) => c.startsWith('destroy:')),
+    ['destroy:dev1', 'destroy:port1', 'destroy:dev2', 'destroy:port2'],
+    'one widget left behind is one suggestion list and one live region left in the body');
+});
+
+test('destroyAutocompletesIn__the_widget_is_found_by_the_jquery_ui_class__not_by_our_selectors', () => {
+  const calls = [];
+  teardown()(pane('acleditor_pane', [field('left_rule', true, calls)], calls));
+  assert.deepStrictEqual(calls[0], 'query:.ui-autocomplete-input',
+    'jQuery UI marks a field it has taken over, so a site-local field is covered too');
+  const body = extract('destroyAutocompletesIn');
+  assert.ok(!/nd_[\w-]+/.test(body),
+    'naming netdisco selectors here would miss any field added later');
+});
+
+test('destroyAutocompletesIn__a_field_was_never_initialized__leaves_it_alone', () => {
+  const calls = [];
+  const fields = [field('plain', false, calls), field('typeahead', true, calls)];
+  teardown()(pane('jobqueue_pane', fields, calls));
+  assert.deepStrictEqual(calls.filter((c) => c.startsWith('destroy:')), ['destroy:typeahead']);
+});
+
+test('destroyAutocompletesIn__the_pane_holds_no_fields__does_nothing', () => {
+  const calls = [];
+  teardown()(pane('netmap_pane', [], calls));
+  assert.deepStrictEqual(calls, ['query:.ui-autocomplete-input']);
+});
+
+test('destroyAutocompletesIn__there_is_no_pane__does_nothing', () => {
+  assert.doesNotThrow(() => { teardown()(null) });
+  assert.doesNotThrow(() => { teardown()(undefined) });
+});
+
+// --- the listener ----------------------------------------------------------
+
+test('htmxBeforeRequest__a_pane_with_autocomplete_fields__destroys_them_before_emptying', () => {
+  const calls = [];
+  const fields = [field('dev1', true, calls), field('port1', true, calls)];
+  const target = pane('topology_pane', fields, calls);
+  beforeRequest()({ detail: { target: target } });
+  assert.deepStrictEqual(calls,
+    ['query:.ui-autocomplete-input', 'destroy:dev1', 'destroy:port1', 'innerHTML=""'],
+    'after the empty the fields are gone and their widgets can no longer be reached');
+});
+
+test('htmxBeforeRequest__the_jobqueue_pane__is_left_untouched', () => {
+  const calls = [];
+  const target = pane('jobqueue_pane', [field('backend', true, calls)], calls);
+  beforeRequest()({ detail: { target: target } });
+  assert.deepStrictEqual(calls, [],
+    'it refreshes on a timer and is not emptied, so nothing in it is on its way out here');
+});
+
+test('htmxBeforeRequest__a_target_that_is_not_a_pane__is_left_untouched', () => {
+  const calls = [];
+  const target = pane('nd_nodes_box', [field('anything', true, calls)], calls);
+  beforeRequest()({ detail: { target: target } });
+  assert.deepStrictEqual(calls, []);
+});


### PR DESCRIPTION
A jQuery UI autocomplete puts its suggestion list and its live region on
document.body rather than beside the field, and only the widget's own destroy
removes them. Destroy runs from jQuery's removal path, which a pane emptied
natively never reaches, so both elements outlive the field they belong to and
the next render of the pane adds another pair per field. They stay attached to
the document, so nothing collects them.

This affects fields that live inside a swapped pane: Admin Topology, the ACL
editor, and a device's SNMP tab. Sidebar fields are not affected, because the
sidebar is not replaced and re-initialising an existing widget updates it
rather than building a second one.

The teardown goes in the handler that empties the outgoing pane, which is the
last point at which the fields still exist. Fields are matched by the class
jQuery UI puts on one it has taken over, so a field added by a site-local
template is covered without being listed.

It dates from pane loading moving to htmx: 2.105002 for the admin panes and
2.105006 for device, search and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
